### PR TITLE
Button to translate selected text appears for each click by input

### DIFF
--- a/src/app/ContentScript/SelectTranslator/components/TextTranslatorPopup/TextTranslatorPopup.css
+++ b/src/app/ContentScript/SelectTranslator/components/TextTranslatorPopup/TextTranslatorPopup.css
@@ -1,3 +1,8 @@
+/* Make wrapper position absolute, to firefox do not prevent a focus reset */
+.TextTranslatorPopup:not(.TextTranslatorPopup_mobile) {
+	position: absolute;
+}
+
 /* TranslateButton */
 .TextTranslatorPopup-TranslateButton {
 	display: block;

--- a/src/app/ContentScript/SelectTranslator/components/TextTranslatorPopup/TextTranslatorPopup.tsx
+++ b/src/app/ContentScript/SelectTranslator/components/TextTranslatorPopup/TextTranslatorPopup.tsx
@@ -237,23 +237,25 @@ export const TextTranslatorPopup: FC<TextTranslatorPopupProps> = ({
 	// We use real component instead virtual because require behavior of `position: absolute` instead `fixed`
 	// and implement this logic for virtual component is harder than use real component
 	return (
-		<div className={cnTextTranslatorPopup({}, [cnTheme(theme)])}>
+		<>
 			{/* Render cursor */}
 			<div style={cursorStyle} ref={cursorRef} />
 
-			{/* Render popup which attached to cursor */}
-			<Popup
-				target="anchor"
-				anchor={cursorRef}
-				visible={true}
-				zIndex={zIndex}
-				modifiers={modifiers}
-				onClose={closeHandler}
-				view={translating ? 'default' : undefined}
-				UNSTABLE_updatePosition={updateRef}
-			>
-				{content}
-			</Popup>
-		</div>
+			{/* Render popup attached to cursor */}
+			<div className={cnTextTranslatorPopup({}, [cnTheme(theme)])}>
+				<Popup
+					target="anchor"
+					anchor={cursorRef}
+					visible={true}
+					zIndex={zIndex}
+					modifiers={modifiers}
+					onClose={closeHandler}
+					view={translating ? 'default' : undefined}
+					UNSTABLE_updatePosition={updateRef}
+				>
+					{content}
+				</Popup>
+			</div>
+		</>
 	);
 };


### PR DESCRIPTION
# The problem

Popup wrapper are `div`. It looks Firefox prevent selection reset by mouse down, because while this event a popup wrapper still exists with initial size. Firefox think we click by wrapper.

This problem is not reproduce in chromium browsers

# Solution

We set `position: absolute` for wrapper, so it collapse and Firefox reset selection as expected

# Note

I'm not sure about real cause of problem, it's just my assumption and problem interpretation. My fix works fine