### PR TITLE
feat: add command to open popup

### DIFF
--- a/manifests/manifest.json
+++ b/manifests/manifest.json
@@ -27,5 +27,12 @@
 	"options_ui": {
 		"page": "pages/options/options.html",
 		"open_in_tab": true
+	},
+	"commands": {
+		"_execute_browser_action": {
+			"suggested_key": {
+				"default": "Shift+T"
+			}
+		}
 	}
 }


### PR DESCRIPTION
Advantages:
* More convenient to open the extension popup, for example, if you want to translate a manually imput text.
* In Chromium browsers if the extension "Site access" is set to "On click", this makes a great combination with the "Auto translate" feature. When you visit a site that you want to translate, you can do so by executing the shortcut.
* Generally good for keyboard users.

For reference, my extension has this as well, and I use it exclusively, it's very convenient
https://github.com/WofWca/jumpcutter/blob/d5727fed31bb3b1a654b76ddf38d90ebd6a384e2/src/manifest.json#L35C1-L47