### PR TITLE
style: remove README.md badge for removed workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![CodeQL](https://github.com/translate-tools/linguist/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/translate-tools/linguist/actions/workflows/codeql-analysis.yml)
-
 Linguist is a powerful browser extension that is ready to replace your favorite translation service.
 
 Translate web pages, highlighted text, Netflix subtitles, private messages, speak the translated text, and save important translations to your personal dictionary to learn words in 130 languages.


### PR DESCRIPTION
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
closes #434.
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

# Problem

The badge for `CodeQL` is no longer present because we removed the `CodeQL` workflow that we set up manually.

<!-- Explain the exact problem we have. -->

# How this change fixes it

This pull request removes the broken badge link.