### PR TITLE
Remove building and signing XPI file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           AMO_SECRET: ${{ secrets.AMO_SECRET }}
         run: |
           mkdir ./AMO
-          npx web-ext sign --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --id "{e3fc2d33-09fc-4fe8-9331-d0a464698035}" --source-dir ./firefox-standalone --artifacts-dir ./AMO
+          npx web-ext sign --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
           mv AMO/*.xpi AMO/linguist.xpi
 
       - name: Archive build files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,14 @@ jobs:
           npx crx pack chromium -o linguist.crx -p ./crx.pem
           ls -al ./
 
-      - name: Build XPI file for firefox
+      - name: Build XPI file for firefox-standalone
         working-directory: "./build"
         env:
           AMO_KEY: ${{ secrets.AMO_KEY }}
           AMO_SECRET: ${{ secrets.AMO_SECRET }}
         run: |
           mkdir ./AMO
-          npx web-ext sign --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --id "{e3fc2d33-09fc-4fe8-9331-d0a464698035}" --source-dir ./firefox --artifacts-dir ./AMO
+          npx web-ext sign --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --id "{e3fc2d33-09fc-4fe8-9331-d0a464698035}" --source-dir ./firefox-standalone --artifacts-dir ./AMO
           mv AMO/*.xpi AMO/linguist.xpi
 
       - name: Archive build files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ steps.cache-thirdparty-restore.outputs.cache-primary-key }}
 
       - name: Build some targets for test
-        run: make prepare buildFirefox packAll lintBuilds
+        run: make prepare buildFirefox buildFirefoxStandalone packAll lintBuilds
 
       - name: Archive build files
         uses: actions/upload-artifact@v4

--- a/makefile
+++ b/makefile
@@ -20,10 +20,12 @@ buildThirdparty:
 buildAll:
 	mkdir -p ./build
 	chmod 777 ./build
-	${DOCKER_COMPOSE} run linguist make buildFirefox buildChromium buildChrome
+	${DOCKER_COMPOSE} run linguist make buildFirefox buildFirefoxStandalone buildChromium buildChrome
 
 buildFirefox:
 	NODE_ENV=production EXT_TARGET=firefox npx webpack-cli -c ./webpack.config.js
+buildFirefoxStandalone:
+	NODE_ENV=production EXT_TARGET=firefox-standalone npx webpack-cli -c ./webpack.config.js
 buildChromium:
 	NODE_ENV=production EXT_TARGET=chromium npx webpack-cli -c ./webpack.config.js
 buildChrome:

--- a/manifests/firefox-standalone.json
+++ b/manifests/firefox-standalone.json
@@ -1,0 +1,11 @@
+{
+	"browser_action": {
+		"theme_icons": [
+			{
+				"light": "static/logo/logo-icon-simple-light.png",
+				"dark": "static/logo/logo-icon-simple-dark.png",
+				"size": 32
+			}
+		]
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -110,14 +110,6 @@ module.exports = {
 
 						// Patch manifest with production overrides
 						const productionOverridesMap = {
-							firefox: {
-								// eslint-disable-next-line camelcase
-								browser_specific_settings: {
-									gecko: {
-										id: '{e5b6e4ac-ec96-44f5-b257-e4d3c8291b41}',
-									},
-								},
-							},
 							'firefox-standalone': {
 								// eslint-disable-next-line camelcase
 								browser_specific_settings: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,30 @@ module.exports = {
 							manifest = merge(manifest, targetManifest);
 						}
 
+						// Patch manifest with production overrides
+						const productionOverridesMap = {
+							firefox: {
+								// eslint-disable-next-line camelcase
+								browser_specific_settings: {
+									gecko: {
+										id: '{e5b6e4ac-ec96-44f5-b257-e4d3c8291b41}',
+									},
+								},
+							},
+							'firefox-standalone': {
+								// eslint-disable-next-line camelcase
+								browser_specific_settings: {
+									gecko: {
+										id: '{e3fc2d33-09fc-4fe8-9331-d0a464698035}',
+									},
+								},
+							},
+						};
+						if (isProduction && target in productionOverridesMap) {
+							const productionOverrides = productionOverridesMap[target];
+							manifest = merge(manifest, productionOverrides);
+						}
+
 						// Set version
 						manifest.version = package.version;
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ const devtool = isProduction ? undefined : 'inline-source-map';
 const isFastBuild = !isProduction && process.env.FAST_BUILD === 'on';
 const isBundleAnalyzingEnabled = Boolean(process.env.DEBUG) || !isProduction;
 
-const targetsList = ['firefox', 'chromium', 'chrome'];
+const targetsList = ['firefox', 'firefox-standalone', 'chromium', 'chrome'];
 if (targetsList.indexOf(target) === -1) {
 	throw new Error(`Invalid target "${target}" in EXT_TARGET`);
 }


### PR DESCRIPTION
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

Closes #445 

# Problem

<!-- Explain the exact problem we have. -->

We have to pass addon id in manifest now, to build XPI file.

# How this change fixes it

Added new target `firefox-standalone` for build XPI file.

Manifest will be overridden while building with production flag, and id will be added. This is important to add id only for production build, because otherwise we may have problems with debug addons who uses real addon ID, since addons will use an original storage that may corrupt data.