### PR TITLE
Remove containers after run

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,12 +15,12 @@ build: clean prepare buildThirdparty buildAll packAll lintBuilds
 
 buildThirdparty:
 	mkdir -p ./thirdparty/bergamot/build && chmod 777 ./thirdparty/bergamot/build
-	${DOCKER_COMPOSE} run bergamot make build
+	${DOCKER_COMPOSE} run --rm bergamot make build
 
 buildAll:
 	mkdir -p ./build
 	chmod 777 ./build
-	${DOCKER_COMPOSE} run linguist make buildFirefox buildFirefoxStandalone buildChromium buildChrome
+	${DOCKER_COMPOSE} run --rm linguist make buildFirefox buildFirefoxStandalone buildChromium buildChrome
 
 buildFirefox:
 	NODE_ENV=production EXT_TARGET=firefox npx webpack-cli -c ./webpack.config.js


### PR DESCRIPTION
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

# Problem

<!-- Explain the exact problem we have. -->

`make build` produces a lot of orphaned containers

# How this change fixes it

Add --rm flag