### PR TITLE
Chinese language is not available for google translator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@popperjs/core": "^2.11.5",
 				"@react-aria/interactions": "^3.9.1",
 				"@react-aria/utils": "^3.13.1",
-				"@translate-tools/core": "^2.0.0",
+				"@translate-tools/core": "^2.0.1",
 				"colord": "^2.9.1",
 				"domtranslator": "^0.0.1",
 				"effector": "^22.4.1",
@@ -4610,10 +4610,9 @@
 			}
 		},
 		"node_modules/@translate-tools/core": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@translate-tools/core/-/core-2.0.0.tgz",
-			"integrity": "sha512-JxFYcyI46oGwULXeal80bU2bNGYHQq+VLKNVF37LlT95XQVI/Cpnbs8V/z+FUJ1/XI6pZLrZQ3LKjm/C2MMUfg==",
-			"license": "Apache-2.0",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@translate-tools/core/-/core-2.0.1.tgz",
+			"integrity": "sha512-2U6ExZObgqOMsNQtxdW3hDByhrhopxa/2Na6a+BE4FohH3l91gxatGPMdPwR5v5odv9J++Ji/JvTrRmHQ7U+dA==",
 			"dependencies": {
 				"@xmldom/xmldom": "^0.8.1",
 				"isomorphic-fetch": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"@popperjs/core": "^2.11.5",
 		"@react-aria/interactions": "^3.9.1",
 		"@react-aria/utils": "^3.13.1",
-		"@translate-tools/core": "^2.0.0",
+		"@translate-tools/core": "^2.0.1",
 		"colord": "^2.9.1",
 		"domtranslator": "^0.0.1",
 		"effector": "^22.4.1",


### PR DESCRIPTION
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

Closes #461

# Problem

Google translator did not return `zh`, but instead returned `zh-*` languages. Problem been fixed in core package.

<!-- Explain the exact problem we have. -->

# How this change fixes it

Core package been updated