### PR TITLE
Release 6.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/prepare-build
 
+      - name: Set variables
+        run: echo "PROJECT_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
+
+      - name: Test variables
+        run: echo ${{ env.PROJECT_VERSION }}
+
       - name: Build all targets
         run: |
           make build
@@ -51,6 +57,8 @@ jobs:
       - name: Publish release on GitHub
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ env.PROJECT_VERSION }}
+          name: ${{ env.PROJECT_VERSION }}
           files: |
             build/AMO/linguist.xpi
             build/linguist.crx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "PROJECT_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
 
       - name: Test variables
-        run: echo ${{ env.PROJECT_VERSION }} ${{ github.sha }}
+        run: echo ${{ env.PROJECT_VERSION }}
 
       - name: Build all targets
         run: |
@@ -45,6 +45,7 @@ jobs:
       #     mkdir ./AMO
       #     npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
       #     mv AMO/*.xpi AMO/linguist.xpi
+
       - name: Archive build files
         uses: actions/upload-artifact@v4
         id: upload-build-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Set variables
         run: echo "PROJECT_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
 
+      - name: Test variables
+        run: echo ${{ env.PROJECT_VERSION }}
+
       - name: Build all targets
         run: |
           make build
@@ -33,15 +36,15 @@ jobs:
           npx crx pack chromium -o linguist.crx -p ./crx.pem
           ls -al ./
 
-      - name: Build XPI file for firefox-standalone
-        working-directory: "./build"
-        env:
-          AMO_KEY: ${{ secrets.AMO_KEY }}
-          AMO_SECRET: ${{ secrets.AMO_SECRET }}
-        run: |
-          mkdir ./AMO
-          npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
-          mv AMO/*.xpi AMO/linguist.xpi
+      # - name: Build XPI file for firefox-standalone
+      #   working-directory: "./build"
+      #   env:
+      #     AMO_KEY: ${{ secrets.AMO_KEY }}
+      #     AMO_SECRET: ${{ secrets.AMO_SECRET }}
+      #   run: |
+      #     mkdir ./AMO
+      #     npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
+      #     mv AMO/*.xpi AMO/linguist.xpi
 
       - name: Archive build files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,6 @@ jobs:
 
       - name: Publish release on GitHub
         uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
             build/AMO/linguist.xpi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,15 +36,15 @@ jobs:
           npx crx pack chromium -o linguist.crx -p ./crx.pem
           ls -al ./
 
-      - name: Build XPI file for firefox-standalone
-        working-directory: "./build"
-        env:
-          AMO_KEY: ${{ secrets.AMO_KEY }}
-          AMO_SECRET: ${{ secrets.AMO_SECRET }}
-        run: |
-          mkdir ./AMO
-          npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
-          mv AMO/*.xpi AMO/linguist.xpi
+      # - name: Build XPI file for firefox-standalone
+      #   working-directory: "./build"
+      #   env:
+      #     AMO_KEY: ${{ secrets.AMO_KEY }}
+      #     AMO_SECRET: ${{ secrets.AMO_SECRET }}
+      #   run: |
+      #     mkdir ./AMO
+      #     npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
+      #     mv AMO/*.xpi AMO/linguist.xpi
 
       - name: Archive build files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: echo "PROJECT_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
 
       - name: Test variables
-        run: echo ${{ env.PROJECT_VERSION }}
+        run: echo ${{ env.PROJECT_VERSION }} ${{ github.sha }}
 
       - name: Build all targets
         run: |
@@ -45,7 +45,6 @@ jobs:
       #     mkdir ./AMO
       #     npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
       #     mv AMO/*.xpi AMO/linguist.xpi
-
       - name: Archive build files
         uses: actions/upload-artifact@v4
         id: upload-build-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           # Use tag name from `package.json`
+          # WARNING: source code in release will be bound to this tag,
+          # so if any changes in code been inserted, we must create another version and tag
           tag_name: v${{ env.PROJECT_VERSION }}
           name: v${{ env.PROJECT_VERSION }}
           # Use current commit hash, instead of main branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,11 +51,15 @@ jobs:
           name: build-files
           path: build
 
+        # Read docs on https://github.com/softprops/action-gh-release
       - name: Publish release on GitHub
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ env.PROJECT_VERSION }}
-          name: ${{ env.PROJECT_VERSION }}
+          # Use tag name from `package.json`
+          tag_name: v${{ env.PROJECT_VERSION }}
+          name: v${{ env.PROJECT_VERSION }}
+          # Use current commit hash, instead of main branch
+          target_commitish: ${{ github.sha }}
           files: |
             build/AMO/linguist.xpi
             build/linguist.crx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Set variables
         run: echo "PROJECT_VERSION=$(jq -r .version package.json)" >> $GITHUB_ENV
 
-      - name: Test variables
-        run: echo ${{ env.PROJECT_VERSION }}
-
       - name: Build all targets
         run: |
           make build
@@ -36,15 +33,15 @@ jobs:
           npx crx pack chromium -o linguist.crx -p ./crx.pem
           ls -al ./
 
-      # - name: Build XPI file for firefox-standalone
-      #   working-directory: "./build"
-      #   env:
-      #     AMO_KEY: ${{ secrets.AMO_KEY }}
-      #     AMO_SECRET: ${{ secrets.AMO_SECRET }}
-      #   run: |
-      #     mkdir ./AMO
-      #     npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
-      #     mv AMO/*.xpi AMO/linguist.xpi
+      - name: Build XPI file for firefox-standalone
+        working-directory: "./build"
+        env:
+          AMO_KEY: ${{ secrets.AMO_KEY }}
+          AMO_SECRET: ${{ secrets.AMO_SECRET }}
+        run: |
+          mkdir ./AMO
+          npx web-ext sign --channel unlisted --api-key "$AMO_KEY" --api-secret "$AMO_SECRET" --source-dir ./firefox-standalone --artifacts-dir ./AMO
+          mv AMO/*.xpi AMO/linguist.xpi
 
       - name: Archive build files
         uses: actions/upload-artifact@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "browser-addon",
-	"version": "5.0.17",
+	"version": "6.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "browser-addon",
-			"version": "5.0.17",
+			"version": "6.0.0",
 			"license": "GPL-3.0",
 			"dependencies": {
 				"@bem-react/classname": "^1.5.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "browser-addon",
-	"version": "5.0.17",
+	"version": "6.0.0",
 	"description": "Browser addon for fast translate text and pages",
 	"license": "GPL-3.0",
 	"author": "Vitonsky <https://github.com/vitonsky>",

--- a/scripts/testBuildArchives.sh
+++ b/scripts/testBuildArchives.sh
@@ -4,7 +4,10 @@
 
 testDir=tests
 
-for packageArchive in `find . -maxdepth 1 -type f -name '*.zip' -print`;
+# We check only firefox, because web-ext is not stable work with chromium manifest v3,
+# it emit `MANIFEST_FIELD_UNSUPPORTED` for `service_worker` and `EXTENSION_ID_REQUIRED`
+# See logs example in https://github.com/translate-tools/linguist/actions/runs/9546724264/job/26310185905?pr=465
+for packageArchive in `find . -maxdepth 1 -type f -name 'firefox*.zip' -print`;
 do
 	unpackDir="$testDir/$(basename -s .zip "$packageArchive")"
 


### PR DESCRIPTION
New version

Changes in current PR also make available to trigger release action manually from any branch. Release eventually will be bound to corresponding tag that match with version in `package.json`.

We still must release new version if any changes in code appears, but we may debug CI with no generate a lot of unused versions.