### PR TITLE
6.0 version not work on chrome

### DIFF
--- a/src/app/ConfigStorage/ConfigStorage.migrations.ts
+++ b/src/app/ConfigStorage/ConfigStorage.migrations.ts
@@ -29,7 +29,7 @@ const migrations: Migration[] = [
 				const mergedData = { ...actualData, ...storageData };
 
 				// Write data
-				browser.storage.local.set({
+				await browser.storage.local.set({
 					[storageNameV2]: mergedData,
 				});
 			}
@@ -63,7 +63,7 @@ const migrations: Migration[] = [
 			}
 
 			// Write data
-			browser.storage.local.set({
+			await browser.storage.local.set({
 				[storageNameV2]: {
 					...newData,
 					selectTranslator: {
@@ -104,7 +104,7 @@ const migrations: Migration[] = [
 			}
 
 			// Write data
-			browser.storage.local.set({ [storageName]: updatedConfig });
+			await browser.storage.local.set({ [storageName]: updatedConfig });
 		},
 	},
 	{

--- a/src/app/ConfigStorage/ConfigStorage.migrations.ts
+++ b/src/app/ConfigStorage/ConfigStorage.migrations.ts
@@ -1,7 +1,9 @@
 import browser from 'webextension-polyfill';
 
-import { DEFAULT_TRANSLATOR, DEFAULT_TTS } from '../../config';
+import { DEFAULT_TRANSLATOR, DEFAULT_TTS, defaultConfig } from '../../config';
 import { createMigrationTask, Migration } from '../../lib/migrations/createMigrationTask';
+import { decodeStruct } from '../../lib/types';
+import { AppConfig } from '../../types/runtime';
 
 const migrations: Migration[] = [
 	{
@@ -131,6 +133,24 @@ const migrations: Migration[] = [
 			await browser.storage.local.set({ [storageName]: updatedConfig });
 		},
 	},
+	{
+		version: 7,
+		async migrate() {
+			// Empty migration, to bump migration number and to trigger hook for repair config
+		},
+	},
 ];
 
-export const ConfigStorageMigration = createMigrationTask(migrations);
+export const ConfigStorageMigration = createMigrationTask(migrations, {
+	onComplete: async () => {
+		// Repair config if necessary
+		const storageName = 'appConfig';
+		const { [storageName]: config } = await browser.storage.local.get(storageName);
+
+		const { errors } = decodeStruct(AppConfig, config);
+		if (errors === null) return;
+
+		console.warn('Config object is invalid, fallback to default config', errors);
+		await browser.storage.local.set({ [storageName]: defaultConfig });
+	},
+});

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -86,18 +86,14 @@ export class App {
 		// Setup sandboxed iframes
 		if (isChromium()) {
 			// Currently `offscreen` API is non standard, so we cast type
-			const offscreen = (browser as any).offscreen;
+			const offscreen = (globalThis as any).chrome.offscreen;
 
 			// We may have only one offscreen document, but we need more,
 			// so we create only one "main" document, that creates embedded iframes
 			try {
 				offscreen.createDocument({
 					url: 'offscreen-documents/main/main.html',
-					reasons: [
-						offscreen.Reason.WORKERS,
-						offscreen.Reason.IFRAME_SCRIPTING,
-						offscreen.Reason.MATCH_MEDIA,
-					],
+					reasons: ['WORKERS', 'IFRAME_SCRIPTING', 'MATCH_MEDIA'],
 					justification:
 						'Main offscreen document, to run WASM and custom translators code in sandbox',
 				});

--- a/src/lib/migrations/MigrationsExecutor/PersistentMigrationsExecutor.ts
+++ b/src/lib/migrations/MigrationsExecutor/PersistentMigrationsExecutor.ts
@@ -76,6 +76,11 @@ export class PersistentMigrationsExecutor {
 
 			await migration.migrate(currentVersion, latestVersion);
 
+			const { hooks = {} } = migration;
+			if (hooks.onComplete) {
+				await hooks.onComplete();
+			}
+
 			// Update storage version
 			migrationsVersions[name] = latestVersion;
 			await this.storage.setMigrationsVersions(migrationsVersions);

--- a/src/lib/migrations/createMigrationTask.ts
+++ b/src/lib/migrations/createMigrationTask.ts
@@ -13,6 +13,10 @@ export type Migration = {
 	migrate: (previousVersion: number) => Promise<void>;
 };
 
+export type MigrationHooks = {
+	onComplete?: () => Promise<void>;
+};
+
 /**
  * Task to migrate from one version to another
  * Task may execute several migrations, so it may take a time
@@ -29,12 +33,17 @@ export type MigrationTask = {
 	 * WARNING: previous version may contain `0` in case when data structure run migration first time
 	 */
 	migrate: (previousVersion: number, currentVersion: number) => Promise<void>;
+
+	hooks?: MigrationHooks;
 };
 
 /**
  * Build migration task from migrations list
  */
-export const createMigrationTask = (migrations: Migration[]): MigrationTask => {
+export const createMigrationTask = (
+	migrations: Migration[],
+	hooks?: MigrationHooks,
+): MigrationTask => {
 	const sortedMigrations = migrations.sort(
 		(migration1, migration2) => migration1.version - migration2.version,
 	);
@@ -47,6 +56,7 @@ export const createMigrationTask = (migrations: Migration[]): MigrationTask => {
 
 	return {
 		version: lastMigrationVersion,
+		hooks,
 		migrate: async (fromVersion: number, toVersion: number) => {
 			const migrationsToApply = sortedMigrations.filter(
 				(migration) =>

--- a/test/setupFiles/utils.js
+++ b/test/setupFiles/utils.js
@@ -1,0 +1,31 @@
+const addRandomDelaysForMethods = (object, methods) => {
+	function getRandomInt(max = 1) {
+		return Math.floor(Math.random() * max);
+	}
+
+	return new Proxy(object, {
+		get(target, prop) {
+			const object = target[prop];
+			if (typeof object !== 'function') return object;
+
+			const isNeedDelay = methods.includes(prop);
+
+			return (...args) => {
+				if (!isNeedDelay) {
+					return object(...args);
+				}
+
+				return Promise.resolve().then(async () => {
+					const delay = getRandomInt(20);
+
+					console.log('Wait a delay', delay);
+					await new Promise((res) => setTimeout(res, delay));
+
+					return object(...args);
+				});
+			};
+		},
+	});
+};
+
+module.exports = { addRandomDelaysForMethods };

--- a/test/setupFiles/utils.js
+++ b/test/setupFiles/utils.js
@@ -18,7 +18,6 @@ const addRandomDelaysForMethods = (object, methods) => {
 				return Promise.resolve().then(async () => {
 					const delay = getRandomInt(20);
 
-					console.log('Wait a delay', delay);
 					await new Promise((res) => setTimeout(res, delay));
 
 					return object(...args);

--- a/test/setupFiles/webextension.js
+++ b/test/setupFiles/webextension.js
@@ -13,3 +13,34 @@ globalThis.location = new URL('/_generated_background_page.html', extBasePath);
 globalThis.navigator = {
 	userAgent: 'node.js',
 };
+
+// Add random delays for async operations,
+// to make tests closer to reality
+const originalStorageLocal = chrome.storage.local;
+chrome.storage.local = new Proxy(originalStorageLocal, {
+	get(target, prop) {
+		const object = target[prop];
+		if (typeof object !== 'function') return object;
+
+		const isNeedDelay = ['get', 'set'].includes(prop);
+
+		return (...args) => {
+			if (!isNeedDelay) {
+				return object(...args);
+			}
+
+			return Promise.resolve().then(async () => {
+				function getRandomInt(max = 1) {
+					return Math.floor(Math.random() * max);
+				}
+
+				const delay = getRandomInt(20);
+
+				console.log('Wait a delay', delay);
+				await new Promise((res) => setTimeout(res, delay));
+
+				return object(...args);
+			});
+		};
+	},
+});

--- a/test/setupFiles/webextension.js
+++ b/test/setupFiles/webextension.js
@@ -14,33 +14,8 @@ globalThis.navigator = {
 	userAgent: 'node.js',
 };
 
+const { addRandomDelaysForMethods } = require('./utils');
+
 // Add random delays for async operations,
 // to make tests closer to reality
-const originalStorageLocal = chrome.storage.local;
-chrome.storage.local = new Proxy(originalStorageLocal, {
-	get(target, prop) {
-		const object = target[prop];
-		if (typeof object !== 'function') return object;
-
-		const isNeedDelay = ['get', 'set'].includes(prop);
-
-		return (...args) => {
-			if (!isNeedDelay) {
-				return object(...args);
-			}
-
-			return Promise.resolve().then(async () => {
-				function getRandomInt(max = 1) {
-					return Math.floor(Math.random() * max);
-				}
-
-				const delay = getRandomInt(20);
-
-				console.log('Wait a delay', delay);
-				await new Promise((res) => setTimeout(res, delay));
-
-				return object(...args);
-			});
-		};
-	},
-});
+chrome.storage.local = addRandomDelaysForMethods(chrome.storage.local, ['get', 'set']);


### PR DESCRIPTION
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

Closes #468 and #470

# The problem

New release 6.0.0 does not work for some chrome users.

Investigation revealed 2 problem:

### Config are broken for some users

According to the [user report](https://github.com/translate-tools/linguist/issues/468#issuecomment-2177447608), property `appConfig` contains only one value.

While debugging been found the root cause of this bug, our config migrations use an async calls for methods in `browser.storage.local`, but some migrations does not use `await` keyword, that make possible a race condition where storage value overwrites multiple times in not determined order, so result value is unpredictable.

We did not catch a bug, because tests uses a mocked extensions API from package https://github.com/RickyMarou/jest-webextension-mock where did not implemented a random delays, so our tests did not imitate a case when promises resolves with different delays.

Also, it is important to mention that bug been occurred not for all users, but only for some users (we don't know the numbers, unfortunately). No one my personal PC did not reproduce a bug.

### Old chrome versions does not have a constants with reasons for offscreen documents creation

One of user reports contains the error below:

![image](https://github.com/translate-tools/linguist/assets/86191922/f82a319d-3c76-4937-b383-24917ed8abd3)

User report that environment is "Windows 7 pro and chrome 109 portable".

Even considering legacy OS and browser version, we found that chrome 109 release date is "January 10, 2023" that is only 1.5 years ago, so we should support such browsers when it possible.

It looks the problem here is chrome 109 does not have a dictionary in property `chrome.offscreen.Reason`.

# The solution

The first problem with invalid config is pretty dangerous. Our changes to fix it is:
- added `await` keywords in migrations, to prevent a problem for the future
- implemented mechanism to run some code after migration with "hooks". We implemented hook, to fix broken config after all config migrations, to ensure config will be correct even if previously it been broken. To run this mechanism, we added an empty migration. We did not add the code to migration, because it is not reliable to fix config in migration, since migration must be immutable, but code to validate correct config and object with default config will be changed with a time.
- updated scripts who configure test environment. Methods of storage object been patched, to add small random delays. We tested behavior and may confirm that bug reproduces with code before changes
- added tests for call migrations multiple times to catch any possible race conditions in future

For the second problem we replaced constant values to a string literals