### PR TITLE
Fix flaky test for text translator storage

### DIFF
--- a/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
+++ b/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
@@ -53,9 +53,7 @@ export class TextTranslatorStorage {
 		const actualData = await this.getData();
 
 		// Protect from null
-		if (typeof actualData === null) {
-			throw new TypeError('Cant merge with null');
-		}
+		if (actualData === null) throw new TypeError('Cant merge with null');
 
 		await this.setData({
 			...actualData,

--- a/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
+++ b/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
@@ -34,11 +34,9 @@ export class TextTranslatorStorage {
 		const { [storeName]: tabData } = await browser.storage.local.get(storeName);
 
 		const { defaultData } = this;
-		if (tabData !== undefined) {
-			return tryDecode(storageSignature, tabData, defaultData);
-		} else {
-			return defaultData;
-		}
+		if (tabData === undefined) return defaultData;
+
+		return tryDecode(storageSignature, tabData, defaultData);
 	};
 
 	public setData = async (data: TextTranslatorData) => {

--- a/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
+++ b/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
@@ -57,19 +57,24 @@ export class TextTranslatorStorage {
 			throw new TypeError('Cant merge with null');
 		}
 
-		const mergedData = { ...actualData, ...data } as TextTranslatorData;
-
-		return this.setData(mergedData);
+		await this.setData({
+			...actualData,
+			...data,
+		} as TextTranslatorData);
 	};
 
-	public clear = async () => this.setData(null);
+	public clear = async () => {
+		await this.setData(null);
+	};
 
 	public forgetText = async () => {
 		const data = await this.getData();
 
-		if (data !== null) {
-			data.translate = null;
-			await this.setData(data);
-		}
+		if (data === null) return;
+
+		await this.setData({
+			...data,
+			translate: null,
+		});
 	};
 }

--- a/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
+++ b/src/pages/popup/tabs/TextTranslator/TextTranslator.utils/TextTranslatorStorage.ts
@@ -69,7 +69,7 @@ export class TextTranslatorStorage {
 
 		if (data !== null) {
 			data.translate = null;
-			this.setData(data);
+			await this.setData(data);
 		}
 	};
 }


### PR DESCRIPTION
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

Fixes #546

# Problem

Race condition due to lack of `await` while writing in f5be5092a066c200702dafcf9859b2ae1b474f0e


<!-- Explain the exact problem we have. -->

# How this change fixes it

Added an `await`