### PR TITLE
395 context menu item translate page is sometimes not displayed

### DIFF
--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,1 @@
+export const wait = (time: number) => new Promise((res) => setTimeout(res, time));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ console.log('WebpackConfig', {
 	mode,
 	target,
 	outputPath,
+	isFastBuild,
 });
 
 const offscreenDocuments = ['main', 'worker', 'translator'];


### PR DESCRIPTION
Fixes #395 
<!-- 🔨 If this fully resolves a GitHub issue, put "closes #987" or "fixes #123" here. -->
<!-- See https://vitonsky.net/blog/2023/01/14/pull-request-description/ if you would like to read up on how to write a detailed description for a pull request. -->

# Problem

We have single context menu for all tabs and dynamically update it when user toggle/refresh tab.

While this update we fetch content script for state of page translation and sometimes it happens too quickly, so content script is not ready to response for requests.

This lead us to an exception and `catch` block is hide context menu in result.

# How this change fixes it

Implemented retries mechanism for query content script.

Now background script can wait response (with reasonable deadline time).