### PR TITLE
Offline translation does not work in new version

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -171,7 +171,7 @@ module.exports = {
 				// Offline translator
 				{
 					from: 'thirdparty/bergamot/build/*.{js,wasm}',
-					to: path.join(outputPath, 'thirdparty/bergamot/[name].[ext]'),
+					to: path.join(outputPath, 'thirdparty/bergamot/[name][ext]'),
 				},
 
 				// Serve static files


### PR DESCRIPTION
Closes #578

The problem was in filename template in webpack config. Template is updated.