### PR TITLE
feat: add per-tab translation state badge on toolbar icon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
 				"@types/react-dom": "^17.0.17",
 				"@types/react-infinite-scroller": "^1.2.3",
 				"@types/resize-observer-browser": "^0.1.11",
-				"@types/webextension-polyfill": "^0.9.1",
+				"@types/webextension-polyfill": "^0.12.0",
 				"@typescript-eslint/eslint-plugin": "^8.37.0",
 				"@typescript-eslint/parser": "^8.37.0",
 				"@yandex/themekit": "^1.6.8",
@@ -8862,9 +8862,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/webextension-polyfill": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.9.2.tgz",
-			"integrity": "sha512-op8YeoK60K6/GIx3snWs3JowBZ+/aeSnZzZuuwynA7VARWfzr3st9aQNk9RWfoBx5xqlNZjAsh2QttPUZnabCw==",
+			"version": "0.12.5",
+			"resolved": "https://registry.npmjs.org/@types/webextension-polyfill/-/webextension-polyfill-0.12.5.tgz",
+			"integrity": "sha512-uKSAv6LgcVdINmxXMKBuVIcg/2m5JZugoZO8x20g7j2bXJkPIl/lVGQcDlbV+aXAiTyXT2RA5U5mI4IGCDMQeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -30594,7 +30594,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
@@ -31560,21 +31559,6 @@
 				}
 			}
 		},
-		"node_modules/vite-node/node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
-		},
 		"node_modules/vitest": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
@@ -31816,21 +31800,6 @@
 				"yaml": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/vitest/node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
 			}
 		},
 		"node_modules/void-elements": {
@@ -33538,29 +33507,6 @@
 					"optional": true
 				},
 				"zod": {
-					"optional": true
-				}
-			}
-		},
-		"packages/locales/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
 					"optional": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"@types/react-dom": "^17.0.17",
 		"@types/react-infinite-scroller": "^1.2.3",
 		"@types/resize-observer-browser": "^0.1.11",
-		"@types/webextension-polyfill": "^0.9.1",
+		"@types/webextension-polyfill": "^0.12.0",
 		"@typescript-eslint/eslint-plugin": "^8.37.0",
 		"@typescript-eslint/parser": "^8.37.0",
 		"@yandex/themekit": "^1.6.8",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -324,6 +324,12 @@
 	"settings_option_pageTranslation_detectLanguageByContent_desc": {
 		"message": "Analyze the text on the web page to detect its language. When disabled, the language specified in the <slot id=docs>page metadata</slot> will be used"
 	},
+	"settings_option_pageTranslation_showTranslationBadge": {
+		"message": "Show translation badge"
+	},
+	"settings_option_pageTranslation_showTranslationBadge_desc": {
+		"message": "Show a badge on the toolbar icon reflecting the translation state of the current page"
+	},
 	"settings_option_pageTranslation_enableContextMenu": {
 		"message": "Enable context menu button"
 	},

--- a/src/app/ActionBadge/ActionBadgeController.test.ts
+++ b/src/app/ActionBadge/ActionBadgeController.test.ts
@@ -2,22 +2,6 @@ import { ActionBadgeController } from './ActionBadgeController';
 import type { PageTranslatorStats } from '../ContentScript/PageTranslator/PageTranslator';
 import type { PageTranslatorState } from '../ContentScript/PageTranslator/PageTranslatorController';
 
-vi.mock('webextension-polyfill', () => {
-	const setBadgeText = vi.fn().mockResolvedValue(undefined);
-	const setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
-	const action = { setBadgeText, setBadgeBackgroundColor };
-	return {
-		default: {
-			action,
-			browserAction: action,
-			tabs: {
-				onUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
-				onRemoved: { addListener: vi.fn(), removeListener: vi.fn() },
-			},
-		},
-	};
-});
-
 vi.mock('../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated', () => ({
 	pageTranslatorStateUpdatedHandler: vi.fn(() => vi.fn()),
 }));
@@ -25,9 +9,16 @@ vi.mock('../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated', (
 	pageTranslatorStatsUpdatedHandler: vi.fn(() => vi.fn()),
 }));
 
-import browser from 'webextension-polyfill';
 import { pageTranslatorStateUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated';
 import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated';
+
+// jest-webextension-mock sets up chrome.browserAction; webextension.js shims chrome.action to it.
+// @types/chrome is not installed so we access the mock via globalThis.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const chromeAction = (globalThis as any).chrome.action as {
+	setBadgeText: ReturnType<typeof vi.fn>;
+	setBadgeBackgroundColor: ReturnType<typeof vi.fn>;
+};
 
 const TAB_ID = 1;
 
@@ -35,113 +26,94 @@ beforeEach(() => {
 	vi.clearAllMocks();
 });
 
-test('shows translating badge while segments are pending', () => {
-	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
-		statsCallback = cb;
+function captureStatsCallback() {
+	let captured!: (stats: PageTranslatorStats, tabId?: number) => void;
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementationOnce((cb) => {
+		captured = cb;
 		return vi.fn();
 	});
+	return () => captured;
+}
 
+function captureStateCallback() {
+	let captured!: (state: PageTranslatorState, tabId?: number) => void;
+	vi.mocked(pageTranslatorStateUpdatedHandler).mockImplementationOnce((cb) => {
+		captured = cb;
+		return vi.fn();
+	});
+	return () => captured;
+}
+
+test('shows translating badge while segments are pending', () => {
+	const getStats = captureStatsCallback();
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	statsCallback({ pending: 5, resolved: 0, rejected: 0 }, TAB_ID);
+	getStats()({ pending: 5, resolved: 0, rejected: 0 }, TAB_ID);
 
-	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({
 		text: '...',
 		tabId: TAB_ID,
 	});
-	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
 		color: '#f0a500',
 		tabId: TAB_ID,
 	});
-
-	controller.disable();
 });
 
 test('shows done badge when all segments resolved', () => {
-	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
-		statsCallback = cb;
-		return vi.fn();
-	});
-
+	const getStats = captureStatsCallback();
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	statsCallback({ pending: 0, resolved: 10, rejected: 0 }, TAB_ID);
+	getStats()({ pending: 0, resolved: 10, rejected: 0 }, TAB_ID);
 
-	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
-		text: '✓',
-		tabId: TAB_ID,
-	});
-	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '✓', tabId: TAB_ID });
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
 		color: '#3a8f3a',
 		tabId: TAB_ID,
 	});
-
-	controller.disable();
 });
 
 test('shows partial badge when some segments failed', () => {
-	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
-		statsCallback = cb;
-		return vi.fn();
-	});
-
+	const getStats = captureStatsCallback();
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	statsCallback({ pending: 0, resolved: 7, rejected: 3 }, TAB_ID);
+	getStats()({ pending: 0, resolved: 7, rejected: 3 }, TAB_ID);
 
-	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
-		text: '~',
-		tabId: TAB_ID,
-	});
-	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '~', tabId: TAB_ID });
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
 		color: '#e06000',
 		tabId: TAB_ID,
 	});
-
-	controller.disable();
 });
 
 test('shows error badge when all segments failed', () => {
-	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
-		statsCallback = cb;
-		return vi.fn();
-	});
-
+	const getStats = captureStatsCallback();
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	statsCallback({ pending: 0, resolved: 0, rejected: 5 }, TAB_ID);
+	getStats()({ pending: 0, resolved: 0, rejected: 5 }, TAB_ID);
 
-	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
-		text: '!',
-		tabId: TAB_ID,
-	});
-	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '!', tabId: TAB_ID });
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
 		color: '#cc0000',
 		tabId: TAB_ID,
 	});
-
-	controller.disable();
 });
 
 test('clears badge when translation is stopped', () => {
-	let stateCallback!: (state: PageTranslatorState, tabId?: number) => void;
-	vi.mocked(pageTranslatorStateUpdatedHandler).mockImplementation((cb) => {
-		stateCallback = cb;
-		return vi.fn();
-	});
-
+	const getState = captureStateCallback();
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	stateCallback(
+	getState()(
 		{
 			isTranslated: false,
 			counters: { pending: 0, resolved: 0, rejected: 0 },
@@ -150,60 +122,92 @@ test('clears badge when translation is stopped', () => {
 		TAB_ID,
 	);
 
-	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
-		text: '',
-		tabId: TAB_ID,
-	});
-
-	controller.disable();
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '', tabId: TAB_ID });
 });
 
 test('ignores zero-counter flush from PageTranslator.stop()', () => {
-	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
-		statsCallback = cb;
-		return vi.fn();
-	});
-
+	const getStats = captureStatsCallback();
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	statsCallback({ pending: 0, resolved: 0, rejected: 0 }, TAB_ID);
+	getStats()({ pending: 0, resolved: 0, rejected: 0 }, TAB_ID);
 
-	expect(browser.browserAction.setBadgeText).not.toHaveBeenCalled();
-
-	controller.disable();
+	expect(chromeAction.setBadgeText).not.toHaveBeenCalled();
 });
 
 test('clears badge on tab navigation', () => {
 	const controller = new ActionBadgeController();
+	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	const onTabUpdated = vi.mocked(browser.tabs.onUpdated.addListener).mock
-		.calls[0]?.[0] as Function;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const onTabUpdated = vi.mocked((globalThis as any).chrome.tabs.onUpdated.addListener)
+		.mock.calls[0]?.[0] as (...args: unknown[]) => void;
 	onTabUpdated(TAB_ID, { url: 'https://example.com' }, {});
 
-	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
-		text: '',
-		tabId: TAB_ID,
-	});
-
-	controller.disable();
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '', tabId: TAB_ID });
 });
 
 test('disable() stops responding to events', () => {
-	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
-		statsCallback = cb;
-		return vi.fn();
-	});
-
+	const getStats = captureStatsCallback();
 	const controller = new ActionBadgeController();
 	controller.enable();
 	controller.disable();
 
 	vi.clearAllMocks();
-	statsCallback({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
+	getStats()({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
 
-	expect(browser.browserAction.setBadgeText).not.toHaveBeenCalled();
+	expect(chromeAction.setBadgeText).not.toHaveBeenCalled();
+});
+
+test('disable() clears the badge and toggle cycle produces correct state', () => {
+	const controller = new ActionBadgeController();
+
+	// Cycle 1: translating → disable clears
+	const getStats1 = captureStatsCallback();
+	controller.enable();
+	getStats1()({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({
+		text: '...',
+		tabId: TAB_ID,
+	});
+
+	controller.disable();
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
+
+	vi.clearAllMocks();
+
+	// Cycle 2: partial → disable clears
+	const getStats2 = captureStatsCallback();
+	controller.enable();
+	getStats2()({ pending: 0, resolved: 5, rejected: 2 }, TAB_ID);
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '~', tabId: TAB_ID });
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+		color: '#e06000',
+		tabId: TAB_ID,
+	});
+
+	controller.disable();
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
+
+	vi.clearAllMocks();
+
+	// Cycle 3: all-error → disable clears
+	const getStats3 = captureStatsCallback();
+	controller.enable();
+	getStats3()({ pending: 0, resolved: 0, rejected: 10 }, TAB_ID);
+	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '!', tabId: TAB_ID });
+
+	controller.disable();
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
 });

--- a/src/app/ActionBadge/ActionBadgeController.test.ts
+++ b/src/app/ActionBadge/ActionBadgeController.test.ts
@@ -1,4 +1,6 @@
 import { ActionBadgeController } from './ActionBadgeController';
+import type { PageTranslatorStats } from '../ContentScript/PageTranslator/PageTranslator';
+import type { PageTranslatorState } from '../ContentScript/PageTranslator/PageTranslatorController';
 
 vi.mock('webextension-polyfill', () => {
 	const setBadgeText = vi.fn().mockResolvedValue(undefined);
@@ -29,31 +31,20 @@ import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslat
 
 const TAB_ID = 1;
 
-function setup() {
-	let statsCallback: (stats: any, tabId?: number) => void = () => {};
-	let stateCallback: (state: any, tabId?: number) => void = () => {};
+beforeEach(() => {
+	vi.clearAllMocks();
+});
 
+test('shows translating badge while segments are pending', () => {
+	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
 	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
 		statsCallback = cb;
-		return vi.fn();
-	});
-	vi.mocked(pageTranslatorStateUpdatedHandler).mockImplementation((cb) => {
-		stateCallback = cb;
 		return vi.fn();
 	});
 
 	const controller = new ActionBadgeController();
 	controller.enable();
 
-	return { controller, statsCallback, stateCallback };
-}
-
-beforeEach(() => {
-	vi.clearAllMocks();
-});
-
-test('shows translating badge while segments are pending', () => {
-	const { statsCallback } = setup();
 	statsCallback({ pending: 5, resolved: 0, rejected: 0 }, TAB_ID);
 
 	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
@@ -64,10 +55,20 @@ test('shows translating badge while segments are pending', () => {
 		color: '#f0a500',
 		tabId: TAB_ID,
 	});
+
+	controller.disable();
 });
 
 test('shows done badge when all segments resolved', () => {
-	const { statsCallback } = setup();
+	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
+		statsCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
+
 	statsCallback({ pending: 0, resolved: 10, rejected: 0 }, TAB_ID);
 
 	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
@@ -78,10 +79,20 @@ test('shows done badge when all segments resolved', () => {
 		color: '#3a8f3a',
 		tabId: TAB_ID,
 	});
+
+	controller.disable();
 });
 
 test('shows partial badge when some segments failed', () => {
-	const { statsCallback } = setup();
+	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
+		statsCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
+
 	statsCallback({ pending: 0, resolved: 7, rejected: 3 }, TAB_ID);
 
 	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
@@ -92,10 +103,20 @@ test('shows partial badge when some segments failed', () => {
 		color: '#e06000',
 		tabId: TAB_ID,
 	});
+
+	controller.disable();
 });
 
 test('shows error badge when all segments failed', () => {
-	const { statsCallback } = setup();
+	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
+		statsCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
+
 	statsCallback({ pending: 0, resolved: 0, rejected: 5 }, TAB_ID);
 
 	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
@@ -106,27 +127,58 @@ test('shows error badge when all segments failed', () => {
 		color: '#cc0000',
 		tabId: TAB_ID,
 	});
+
+	controller.disable();
 });
 
 test('clears badge when translation is stopped', () => {
-	const { stateCallback } = setup();
-	stateCallback({ isTranslated: false }, TAB_ID);
+	let stateCallback!: (state: PageTranslatorState, tabId?: number) => void;
+	vi.mocked(pageTranslatorStateUpdatedHandler).mockImplementation((cb) => {
+		stateCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
+
+	stateCallback(
+		{
+			isTranslated: false,
+			counters: { pending: 0, resolved: 0, rejected: 0 },
+			translateDirection: null,
+		},
+		TAB_ID,
+	);
 
 	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
 		text: '',
 		tabId: TAB_ID,
 	});
+
+	controller.disable();
 });
 
 test('ignores zero-counter flush from PageTranslator.stop()', () => {
-	const { statsCallback } = setup();
+	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
+		statsCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
+
 	statsCallback({ pending: 0, resolved: 0, rejected: 0 }, TAB_ID);
 
 	expect(browser.browserAction.setBadgeText).not.toHaveBeenCalled();
+
+	controller.disable();
 });
 
 test('clears badge on tab navigation', () => {
-	setup();
+	const controller = new ActionBadgeController();
+	controller.enable();
+
 	const onTabUpdated = vi.mocked(browser.tabs.onUpdated.addListener).mock
 		.calls[0]?.[0] as Function;
 	onTabUpdated(TAB_ID, { url: 'https://example.com' }, {});
@@ -135,10 +187,19 @@ test('clears badge on tab navigation', () => {
 		text: '',
 		tabId: TAB_ID,
 	});
+
+	controller.disable();
 });
 
 test('disable() stops responding to events', () => {
-	const { controller, statsCallback } = setup();
+	let statsCallback!: (stats: PageTranslatorStats, tabId?: number) => void;
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
+		statsCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
 	controller.disable();
 
 	vi.clearAllMocks();

--- a/src/app/ActionBadge/ActionBadgeController.test.ts
+++ b/src/app/ActionBadge/ActionBadgeController.test.ts
@@ -1,0 +1,148 @@
+import { ActionBadgeController } from './ActionBadgeController';
+
+vi.mock('webextension-polyfill', () => {
+	const setBadgeText = vi.fn().mockResolvedValue(undefined);
+	const setBadgeBackgroundColor = vi.fn().mockResolvedValue(undefined);
+	const action = { setBadgeText, setBadgeBackgroundColor };
+	return {
+		default: {
+			action,
+			browserAction: action,
+			tabs: {
+				onUpdated: { addListener: vi.fn(), removeListener: vi.fn() },
+				onRemoved: { addListener: vi.fn(), removeListener: vi.fn() },
+			},
+		},
+	};
+});
+
+vi.mock('../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated', () => ({
+	pageTranslatorStateUpdatedHandler: vi.fn(() => vi.fn()),
+}));
+vi.mock('../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated', () => ({
+	pageTranslatorStatsUpdatedHandler: vi.fn(() => vi.fn()),
+}));
+
+import browser from 'webextension-polyfill';
+import { pageTranslatorStateUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated';
+import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated';
+
+const TAB_ID = 1;
+
+function setup() {
+	let statsCallback: (stats: any, tabId?: number) => void = () => {};
+	let stateCallback: (state: any, tabId?: number) => void = () => {};
+
+	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementation((cb) => {
+		statsCallback = cb;
+		return vi.fn();
+	});
+	vi.mocked(pageTranslatorStateUpdatedHandler).mockImplementation((cb) => {
+		stateCallback = cb;
+		return vi.fn();
+	});
+
+	const controller = new ActionBadgeController();
+	controller.enable();
+
+	return { controller, statsCallback, stateCallback };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+test('shows translating badge while segments are pending', () => {
+	const { statsCallback } = setup();
+	statsCallback({ pending: 5, resolved: 0, rejected: 0 }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+		text: '...',
+		tabId: TAB_ID,
+	});
+	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+		color: '#f0a500',
+		tabId: TAB_ID,
+	});
+});
+
+test('shows done badge when all segments resolved', () => {
+	const { statsCallback } = setup();
+	statsCallback({ pending: 0, resolved: 10, rejected: 0 }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+		text: '✓',
+		tabId: TAB_ID,
+	});
+	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+		color: '#3a8f3a',
+		tabId: TAB_ID,
+	});
+});
+
+test('shows partial badge when some segments failed', () => {
+	const { statsCallback } = setup();
+	statsCallback({ pending: 0, resolved: 7, rejected: 3 }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+		text: '~',
+		tabId: TAB_ID,
+	});
+	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+		color: '#e06000',
+		tabId: TAB_ID,
+	});
+});
+
+test('shows error badge when all segments failed', () => {
+	const { statsCallback } = setup();
+	statsCallback({ pending: 0, resolved: 0, rejected: 5 }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+		text: '!',
+		tabId: TAB_ID,
+	});
+	expect(browser.browserAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+		color: '#cc0000',
+		tabId: TAB_ID,
+	});
+});
+
+test('clears badge when translation is stopped', () => {
+	const { stateCallback } = setup();
+	stateCallback({ isTranslated: false }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
+});
+
+test('ignores zero-counter flush from PageTranslator.stop()', () => {
+	const { statsCallback } = setup();
+	statsCallback({ pending: 0, resolved: 0, rejected: 0 }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).not.toHaveBeenCalled();
+});
+
+test('clears badge on tab navigation', () => {
+	setup();
+	const onTabUpdated = vi.mocked(browser.tabs.onUpdated.addListener).mock
+		.calls[0]?.[0] as Function;
+	onTabUpdated(TAB_ID, { url: 'https://example.com' }, {});
+
+	expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
+});
+
+test('disable() stops responding to events', () => {
+	const { controller, statsCallback } = setup();
+	controller.disable();
+
+	vi.clearAllMocks();
+	statsCallback({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
+
+	expect(browser.browserAction.setBadgeText).not.toHaveBeenCalled();
+});

--- a/src/app/ActionBadge/ActionBadgeController.test.ts
+++ b/src/app/ActionBadge/ActionBadgeController.test.ts
@@ -1,16 +1,6 @@
 import { ActionBadgeController } from './ActionBadgeController';
-import type { PageTranslatorStats } from '../ContentScript/PageTranslator/PageTranslator';
+import type { PageTranslatorStats } from '../ContentScript/PageTranslator/PageTranslator.tsx';
 import type { PageTranslatorState } from '../ContentScript/PageTranslator/PageTranslatorController';
-
-vi.mock('../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated', () => ({
-	pageTranslatorStateUpdatedHandler: vi.fn(() => vi.fn()),
-}));
-vi.mock('../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated', () => ({
-	pageTranslatorStatsUpdatedHandler: vi.fn(() => vi.fn()),
-}));
-
-import { pageTranslatorStateUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated';
-import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated';
 
 // jest-webextension-mock sets up chrome.browserAction; webextension.js shims chrome.action to it.
 // @types/chrome is not installed so we access the mock via globalThis.
@@ -26,118 +16,136 @@ beforeEach(() => {
 	vi.clearAllMocks();
 });
 
-function captureStatsCallback() {
-	let captured!: (stats: PageTranslatorStats, tabId?: number) => void;
-	vi.mocked(pageTranslatorStatsUpdatedHandler).mockImplementationOnce((cb) => {
-		captured = cb;
-		return vi.fn();
+function makeSubscriber<T>() {
+	let latestCb: ((data: T, tabId?: number) => void) | null = null;
+	const unsubscribe = vi.fn();
+	const subscribe = vi.fn((cb: (data: T, tabId?: number) => void) => {
+		latestCb = cb;
+		return unsubscribe;
 	});
-	return () => captured;
+	return {
+		subscribe,
+		unsubscribe,
+		emit: (data: T, tabId?: number) => {
+			if (!latestCb) throw new Error('subscribe not yet called');
+			latestCb(data, tabId);
+		},
+	};
 }
 
-function captureStateCallback() {
-	let captured!: (state: PageTranslatorState, tabId?: number) => void;
-	vi.mocked(pageTranslatorStateUpdatedHandler).mockImplementationOnce((cb) => {
-		captured = cb;
-		return vi.fn();
-	});
-	return () => captured;
-}
+const STOPPED_STATE: PageTranslatorState = {
+	isTranslated: false,
+	counters: { pending: 0, resolved: 0, rejected: 0 },
+	translateDirection: null,
+};
 
 test('shows translating badge while segments are pending', () => {
-	const getStats = captureStatsCallback();
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	getStats()({ pending: 5, resolved: 0, rejected: 0 }, TAB_ID);
+	stats.emit({ pending: 5, resolved: 0, rejected: 0 }, TAB_ID);
 
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
 		text: '...',
 		tabId: TAB_ID,
 	});
-	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
 		color: '#f0a500',
 		tabId: TAB_ID,
 	});
 });
 
 test('shows done badge when all segments resolved', () => {
-	const getStats = captureStatsCallback();
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	getStats()({ pending: 0, resolved: 10, rejected: 0 }, TAB_ID);
+	stats.emit({ pending: 0, resolved: 10, rejected: 0 }, TAB_ID);
 
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '✓', tabId: TAB_ID });
-	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '✓',
+		tabId: TAB_ID,
+	});
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
 		color: '#3a8f3a',
 		tabId: TAB_ID,
 	});
 });
 
 test('shows partial badge when some segments failed', () => {
-	const getStats = captureStatsCallback();
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	getStats()({ pending: 0, resolved: 7, rejected: 3 }, TAB_ID);
+	stats.emit({ pending: 0, resolved: 7, rejected: 3 }, TAB_ID);
 
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '~', tabId: TAB_ID });
-	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '~',
+		tabId: TAB_ID,
+	});
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
 		color: '#e06000',
 		tabId: TAB_ID,
 	});
 });
 
 test('shows error badge when all segments failed', () => {
-	const getStats = captureStatsCallback();
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	getStats()({ pending: 0, resolved: 0, rejected: 5 }, TAB_ID);
+	stats.emit({ pending: 0, resolved: 0, rejected: 5 }, TAB_ID);
 
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '!', tabId: TAB_ID });
-	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '!',
+		tabId: TAB_ID,
+	});
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
 		color: '#cc0000',
 		tabId: TAB_ID,
 	});
 });
 
 test('clears badge when translation is stopped', () => {
-	const getState = captureStateCallback();
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	getState()(
-		{
-			isTranslated: false,
-			counters: { pending: 0, resolved: 0, rejected: 0 },
-			translateDirection: null,
-		},
-		TAB_ID,
-	);
+	state.emit(STOPPED_STATE, TAB_ID);
 
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '', tabId: TAB_ID });
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
 });
 
 test('ignores zero-counter flush from PageTranslator.stop()', () => {
-	const getStats = captureStatsCallback();
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
-	getStats()({ pending: 0, resolved: 0, rejected: 0 }, TAB_ID);
+	stats.emit({ pending: 0, resolved: 0, rejected: 0 }, TAB_ID);
 
 	expect(chromeAction.setBadgeText).not.toHaveBeenCalled();
 });
 
 test('clears badge on tab navigation', () => {
-	const controller = new ActionBadgeController();
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 	onTestFinished(() => controller.disable());
 	controller.enable();
 
@@ -146,30 +154,46 @@ test('clears badge on tab navigation', () => {
 		.mock.calls[0]?.[0] as (...args: unknown[]) => void;
 	onTabUpdated(TAB_ID, { url: 'https://example.com' }, {});
 
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '', tabId: TAB_ID });
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '',
+		tabId: TAB_ID,
+	});
 });
 
-test('disable() stops responding to events', () => {
-	const getStats = captureStatsCallback();
-	const controller = new ActionBadgeController();
+test('disable() calls unsubscribe and stops responding to events', () => {
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
+
 	controller.enable();
+	expect(state.subscribe).toHaveBeenCalledTimes(1);
+	expect(stats.subscribe).toHaveBeenCalledTimes(1);
+	expect(state.unsubscribe).not.toHaveBeenCalled();
+	expect(stats.unsubscribe).not.toHaveBeenCalled();
+
 	controller.disable();
+	expect(state.unsubscribe).toHaveBeenCalledTimes(1);
+	expect(stats.unsubscribe).toHaveBeenCalledTimes(1);
 
-	vi.clearAllMocks();
-	getStats()({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
-
+	// Callback fires after disable — badge must not update
+	stats.emit({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
 	expect(chromeAction.setBadgeText).not.toHaveBeenCalled();
 });
 
-test('disable() clears the badge and toggle cycle produces correct state', () => {
-	const controller = new ActionBadgeController();
+test('disable() clears badge and toggle cycle produces correct state', () => {
+	const state = makeSubscriber<PageTranslatorState>();
+	const stats = makeSubscriber<PageTranslatorStats>();
+	const controller = new ActionBadgeController(state.subscribe, stats.subscribe);
 
 	// Cycle 1: translating → disable clears
-	const getStats1 = captureStatsCallback();
 	controller.enable();
-	getStats1()({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({
+	stats.emit({ pending: 3, resolved: 0, rejected: 0 }, TAB_ID);
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
 		text: '...',
+		tabId: TAB_ID,
+	});
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
+		color: '#f0a500',
 		tabId: TAB_ID,
 	});
 
@@ -179,14 +203,14 @@ test('disable() clears the badge and toggle cycle produces correct state', () =>
 		tabId: TAB_ID,
 	});
 
-	vi.clearAllMocks();
-
 	// Cycle 2: partial → disable clears
-	const getStats2 = captureStatsCallback();
 	controller.enable();
-	getStats2()({ pending: 0, resolved: 5, rejected: 2 }, TAB_ID);
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '~', tabId: TAB_ID });
-	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenCalledWith({
+	stats.emit({ pending: 0, resolved: 5, rejected: 2 }, TAB_ID);
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '~',
+		tabId: TAB_ID,
+	});
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
 		color: '#e06000',
 		tabId: TAB_ID,
 	});
@@ -197,13 +221,17 @@ test('disable() clears the badge and toggle cycle produces correct state', () =>
 		tabId: TAB_ID,
 	});
 
-	vi.clearAllMocks();
-
 	// Cycle 3: all-error → disable clears
-	const getStats3 = captureStatsCallback();
 	controller.enable();
-	getStats3()({ pending: 0, resolved: 0, rejected: 10 }, TAB_ID);
-	expect(chromeAction.setBadgeText).toHaveBeenCalledWith({ text: '!', tabId: TAB_ID });
+	stats.emit({ pending: 0, resolved: 0, rejected: 10 }, TAB_ID);
+	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({
+		text: '!',
+		tabId: TAB_ID,
+	});
+	expect(chromeAction.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
+		color: '#cc0000',
+		tabId: TAB_ID,
+	});
 
 	controller.disable();
 	expect(chromeAction.setBadgeText).toHaveBeenLastCalledWith({

--- a/src/app/ActionBadge/ActionBadgeController.ts
+++ b/src/app/ActionBadge/ActionBadgeController.ts
@@ -1,5 +1,7 @@
 import browser from 'webextension-polyfill';
 
+import type { PageTranslatorStats } from '../ContentScript/PageTranslator/PageTranslator.tsx';
+import type { PageTranslatorState } from '../ContentScript/PageTranslator/PageTranslatorController';
 import { pageTranslatorStateUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated';
 import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated';
 
@@ -9,6 +11,14 @@ const BADGE_TRANSLATING = { text: '...', color: '#f0a500' };
 const BADGE_DONE = { text: '✓', color: '#3a8f3a' };
 const BADGE_PARTIAL = { text: '~', color: '#e06000' };
 const BADGE_ERROR = { text: '!', color: '#cc0000' };
+
+type Unsubscribe = () => void;
+type StateSubscriber = (
+	cb: (state: PageTranslatorState, tabId?: number) => void,
+) => Unsubscribe;
+type StatsSubscriber = (
+	cb: (stats: PageTranslatorStats, tabId?: number) => void,
+) => Unsubscribe;
 
 /**
  * Shows a per-tab badge on the toolbar icon reflecting page translation state.
@@ -25,18 +35,23 @@ export class ActionBadgeController {
 	private cleanupCallback: null | (() => void) = null;
 	private readonly badgedTabs = new Set<number>();
 
+	constructor(
+		private readonly subscribePageTranslationState: StateSubscriber = pageTranslatorStateUpdatedHandler,
+		private readonly subscribePageTranslationStats: StatsSubscriber = pageTranslatorStatsUpdatedHandler,
+	) {}
+
 	public enable() {
 		if (this.isEnabled) return;
 		this.isEnabled = true;
 
-		const unwatchState = pageTranslatorStateUpdatedHandler((state, tabId) => {
+		const unwatchState = this.subscribePageTranslationState((state, tabId) => {
 			if (tabId === undefined) return;
 			if (!state.isTranslated) {
 				this.clearBadge(tabId);
 			}
 		});
 
-		const unwatchStats = pageTranslatorStatsUpdatedHandler((stats, tabId) => {
+		const unwatchStats = this.subscribePageTranslationStats((stats, tabId) => {
 			if (!this.isEnabled || tabId === undefined) return;
 
 			const { resolved, rejected, pending } = stats;

--- a/src/app/ActionBadge/ActionBadgeController.ts
+++ b/src/app/ActionBadge/ActionBadgeController.ts
@@ -23,7 +23,6 @@ const BADGE_ERROR = { text: '!', color: '#cc0000' };
  * runtime.onMessage listener is registered before the first message arrives.
  */
 export class ActionBadgeController {
-	private readonly clearTimers = new Map<number, ReturnType<typeof setTimeout>>();
 	private isEnabled = false;
 	private cleanupCallback: null | (() => void) = null;
 
@@ -34,13 +33,12 @@ export class ActionBadgeController {
 		const unwatchState = pageTranslatorStateUpdatedHandler((state, tabId) => {
 			if (tabId === undefined) return;
 			if (!state.isTranslated) {
-				this.cancelClearTimer(tabId);
 				this.clearBadge(tabId);
 			}
 		});
 
 		const unwatchStats = pageTranslatorStatsUpdatedHandler((stats, tabId) => {
-			if (tabId === undefined) return;
+			if (!this.isEnabled || tabId === undefined) return;
 
 			const { resolved, rejected, pending } = stats;
 
@@ -48,12 +46,10 @@ export class ActionBadgeController {
 			if (pending === 0 && resolved === 0 && rejected === 0) return;
 
 			if (pending > 0) {
-				this.cancelClearTimer(tabId);
 				this.setBadge(tabId, BADGE_TRANSLATING);
 				return;
 			}
 
-			this.cancelClearTimer(tabId);
 			if (resolved > 0 && rejected === 0) {
 				this.setBadge(tabId, BADGE_DONE);
 			} else if (resolved > 0 && rejected > 0) {
@@ -69,52 +65,34 @@ export class ActionBadgeController {
 			changeInfo: browser.Tabs.OnUpdatedChangeInfoType,
 		) => {
 			if (changeInfo.url !== undefined) {
-				this.cancelClearTimer(tabId);
 				this.clearBadge(tabId);
 			}
 		};
 
-		const onTabRemoved = (tabId: number) => {
-			this.cancelClearTimer(tabId);
-		};
-
 		browser.tabs.onUpdated.addListener(onTabUpdated);
-		browser.tabs.onRemoved.addListener(onTabRemoved);
 
 		this.cleanupCallback = () => {
 			unwatchState();
 			unwatchStats();
 			browser.tabs.onUpdated.removeListener(onTabUpdated);
-			browser.tabs.onRemoved.removeListener(onTabRemoved);
 		};
 	}
 
 	public disable() {
 		if (!this.isEnabled) return;
 		this.isEnabled = false;
-
 		this.cleanupCallback?.();
 		this.cleanupCallback = null;
-
-		for (const tabId of this.clearTimers.keys()) {
-			this.cancelClearTimer(tabId);
-		}
-	}
-
-	private cancelClearTimer(tabId: number) {
-		const timer = this.clearTimers.get(tabId);
-		if (timer !== undefined) {
-			clearTimeout(timer);
-			this.clearTimers.delete(tabId);
-		}
 	}
 
 	private setBadge(tabId: number, badge: { text: string; color: string }) {
-		browserAction.setBadgeText({ text: badge.text, tabId });
-		browserAction.setBadgeBackgroundColor({ color: badge.color, tabId });
+		browserAction.setBadgeText({ text: badge.text, tabId }).catch(() => {});
+		browserAction
+			.setBadgeBackgroundColor({ color: badge.color, tabId })
+			.catch(() => {});
 	}
 
 	private clearBadge(tabId: number) {
-		browserAction.setBadgeText({ text: '', tabId });
+		browserAction.setBadgeText({ text: '', tabId }).catch(() => {});
 	}
 }

--- a/src/app/ActionBadge/ActionBadgeController.ts
+++ b/src/app/ActionBadge/ActionBadgeController.ts
@@ -3,9 +3,7 @@ import browser from 'webextension-polyfill';
 import { pageTranslatorStateUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated';
 import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated';
 
-// webextension-polyfill v0.12+ normalises browser.action for both MV2 and MV3,
-// but @types/webextension-polyfill@0.9.x does not yet include the `action` namespace.
-const browserAction = (browser as any).action as typeof browser.browserAction;
+const browserAction = browser.action;
 
 const BADGE_TRANSLATING = { text: '...', color: '#f0a500' };
 const BADGE_DONE = { text: '✓', color: '#3a8f3a' };
@@ -25,6 +23,7 @@ const BADGE_ERROR = { text: '!', color: '#cc0000' };
 export class ActionBadgeController {
 	private isEnabled = false;
 	private cleanupCallback: null | (() => void) = null;
+	private readonly badgedTabs = new Set<number>();
 
 	public enable() {
 		if (this.isEnabled) return;
@@ -75,6 +74,10 @@ export class ActionBadgeController {
 			unwatchState();
 			unwatchStats();
 			browser.tabs.onUpdated.removeListener(onTabUpdated);
+			for (const tabId of this.badgedTabs) {
+				browserAction.setBadgeText({ text: '', tabId }).catch(() => {});
+			}
+			this.badgedTabs.clear();
 		};
 	}
 
@@ -86,6 +89,7 @@ export class ActionBadgeController {
 	}
 
 	private setBadge(tabId: number, badge: { text: string; color: string }) {
+		this.badgedTabs.add(tabId);
 		browserAction.setBadgeText({ text: badge.text, tabId }).catch(() => {});
 		browserAction
 			.setBadgeBackgroundColor({ color: badge.color, tabId })
@@ -93,6 +97,7 @@ export class ActionBadgeController {
 	}
 
 	private clearBadge(tabId: number) {
+		this.badgedTabs.delete(tabId);
 		browserAction.setBadgeText({ text: '', tabId }).catch(() => {});
 	}
 }

--- a/src/app/ActionBadge/ActionBadgeController.ts
+++ b/src/app/ActionBadge/ActionBadgeController.ts
@@ -1,0 +1,160 @@
+import browser from 'webextension-polyfill';
+
+import { pageTranslatorStateUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStateUpdated';
+import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslator/requests/pageTranslatorStatsUpdated';
+
+// webextension-polyfill v0.12+ normalises browser.action for both MV2 and MV3,
+// but @types/webextension-polyfill@0.9.x does not yet include the `action` namespace.
+// Cast through browserAction (identical API shape) to preserve type safety.
+const browserAction = (browser as any).action as typeof browser.browserAction;
+
+// Badge visual states — text and background colour pairs.
+// Text is limited to 4 characters by the browser; single symbols work best.
+const BADGE_TRANSLATING = { text: '...', color: '#f0a500' }; // yellow — in progress
+const BADGE_DONE        = { text: '✓',   color: '#3a8f3a' }; // green  — all segments translated
+const BADGE_PARTIAL     = { text: '~',   color: '#e06000' }; // orange — some segments failed
+const BADGE_ERROR       = { text: '!',   color: '#cc0000' }; // red    — all segments failed
+
+/**
+ * Shows a per-tab badge on the toolbar icon to reflect page translation state.
+ *
+ * Badge lifecycle:
+ *   1. Translation starts   → '...' (yellow)
+ *   2. All segments done    → '✓'   (green)  — persists until user stops or navigates
+ *      Some segments failed → '~'   (orange) — persists until user stops or navigates
+ *      All segments failed  → '!'   (red)    — persists until user stops or navigates
+ *   3. User stops translate → badge cleared
+ *   4. Tab navigates away   → badge cleared
+ *
+ * Design notes:
+ * - Badge state is driven primarily from pageTranslatorStatsUpdated (segment counters)
+ *   rather than pageTranslatorStateUpdated (on/off). This avoids a race condition where
+ *   stats messages arrive at the service worker before the state message, because
+ *   PageTranslatorController fires the effector store update (which synchronously starts
+ *   translation and emits the first stats) before calling notifyState().
+ * - enable() must be called synchronously during service worker startup, before any
+ *   awaited operations, so that the runtime.onMessage listener is registered before
+ *   the first message arrives on wake-up.
+ */
+export class ActionBadgeController {
+	// Tracks any pending timers per tab. Currently unused for auto-clear (all badges
+	// persist until explicitly cleared), but kept for safety so cancelClearTimer()
+	// can always be called unconditionally before any badge update.
+	private readonly clearTimers = new Map<number, ReturnType<typeof setTimeout>>();
+
+	private isEnabled = false;
+	private cleanupCallback: null | (() => void) = null;
+
+	public enable() {
+		if (this.isEnabled) return;
+		this.isEnabled = true;
+
+		// Listen for translation on/off events from the content script.
+		// Used to clear the badge when the user manually stops translation.
+		// The '...' badge is NOT set here — see stats handler below.
+		const unwatchState = pageTranslatorStateUpdatedHandler((state, tabId) => {
+			if (tabId === undefined) return;
+
+			if (!state.isTranslated) {
+				// User stopped translation — clear badge
+				this.cancelClearTimer(tabId);
+				this.clearBadge(tabId);
+			}
+		});
+
+		// Listen for segment counter updates from the content script.
+		// This is the primary driver for all badge states, including '...'.
+		// Fired at most every 100ms (throttled in PageTranslator).
+		const unwatchStats = pageTranslatorStatsUpdatedHandler((stats, tabId) => {
+			if (tabId === undefined) return;
+
+			const { resolved, rejected, pending } = stats;
+
+			// PageTranslator.stop() resets counters to zero and flushes one last stats
+			// message before sending the state-updated message. Ignore it here — the
+			// state handler above will clear the badge when isTranslated goes false.
+			if (pending === 0 && resolved === 0 && rejected === 0) return;
+
+			if (pending > 0) {
+				// Segments still in flight — show progress badge.
+				// Driving '...' from stats (rather than from the state event) ensures
+				// it appears even if the state message arrives out of order.
+				this.cancelClearTimer(tabId);
+				this.setBadge(tabId, BADGE_TRANSLATING);
+				return;
+			}
+
+			// All segments have settled — show final result badge.
+			if (resolved > 0 && rejected === 0) {
+				// Every segment translated successfully
+				this.cancelClearTimer(tabId);
+				this.setBadge(tabId, BADGE_DONE);
+			} else if (resolved > 0 && rejected > 0) {
+				// Mixed result — page is partially translated
+				this.cancelClearTimer(tabId);
+				this.setBadge(tabId, BADGE_PARTIAL);
+			} else {
+				// resolved === 0, rejected > 0 — translation failed entirely
+				this.cancelClearTimer(tabId);
+				this.setBadge(tabId, BADGE_ERROR);
+			}
+		});
+
+		// Clear badge when the user navigates to a different URL in the tab.
+		// changeInfo.url is only present on actual navigations, not on tab focus changes.
+		const onTabUpdated = (
+			tabId: number,
+			changeInfo: browser.Tabs.OnUpdatedChangeInfoType,
+		) => {
+			if (changeInfo.url !== undefined) {
+				this.cancelClearTimer(tabId);
+				this.clearBadge(tabId);
+			}
+		};
+
+		// Clean up timer state when a tab is closed (badge is destroyed with the tab anyway).
+		const onTabRemoved = (tabId: number) => {
+			this.cancelClearTimer(tabId);
+		};
+
+		browser.tabs.onUpdated.addListener(onTabUpdated);
+		browser.tabs.onRemoved.addListener(onTabRemoved);
+
+		// Store cleanup callbacks so disable() can remove all listeners cleanly.
+		this.cleanupCallback = () => {
+			unwatchState();
+			unwatchStats();
+			browser.tabs.onUpdated.removeListener(onTabUpdated);
+			browser.tabs.onRemoved.removeListener(onTabRemoved);
+		};
+	}
+
+	public disable() {
+		if (!this.isEnabled) return;
+		this.isEnabled = false;
+
+		this.cleanupCallback?.();
+		this.cleanupCallback = null;
+
+		for (const tabId of this.clearTimers.keys()) {
+			this.cancelClearTimer(tabId);
+		}
+	}
+
+	private cancelClearTimer(tabId: number) {
+		const timer = this.clearTimers.get(tabId);
+		if (timer !== undefined) {
+			clearTimeout(timer);
+			this.clearTimers.delete(tabId);
+		}
+	}
+
+	private setBadge(tabId: number, badge: { text: string; color: string }) {
+		browserAction.setBadgeText({ text: badge.text, tabId });
+		browserAction.setBadgeBackgroundColor({ color: badge.color, tabId });
+	}
+
+	private clearBadge(tabId: number) {
+		browserAction.setBadgeText({ text: '', tabId });
+	}
+}

--- a/src/app/ActionBadge/ActionBadgeController.ts
+++ b/src/app/ActionBadge/ActionBadgeController.ts
@@ -5,43 +5,25 @@ import { pageTranslatorStatsUpdatedHandler } from '../ContentScript/PageTranslat
 
 // webextension-polyfill v0.12+ normalises browser.action for both MV2 and MV3,
 // but @types/webextension-polyfill@0.9.x does not yet include the `action` namespace.
-// Cast through browserAction (identical API shape) to preserve type safety.
 const browserAction = (browser as any).action as typeof browser.browserAction;
 
-// Badge visual states — text and background colour pairs.
-// Text is limited to 4 characters by the browser; single symbols work best.
-const BADGE_TRANSLATING = { text: '...', color: '#f0a500' }; // yellow — in progress
-const BADGE_DONE        = { text: '✓',   color: '#3a8f3a' }; // green  — all segments translated
-const BADGE_PARTIAL     = { text: '~',   color: '#e06000' }; // orange — some segments failed
-const BADGE_ERROR       = { text: '!',   color: '#cc0000' }; // red    — all segments failed
+const BADGE_TRANSLATING = { text: '...', color: '#f0a500' };
+const BADGE_DONE = { text: '✓', color: '#3a8f3a' };
+const BADGE_PARTIAL = { text: '~', color: '#e06000' };
+const BADGE_ERROR = { text: '!', color: '#cc0000' };
 
 /**
- * Shows a per-tab badge on the toolbar icon to reflect page translation state.
+ * Shows a per-tab badge on the toolbar icon reflecting page translation state.
  *
- * Badge lifecycle:
- *   1. Translation starts   → '...' (yellow)
- *   2. All segments done    → '✓'   (green)  — persists until user stops or navigates
- *      Some segments failed → '~'   (orange) — persists until user stops or navigates
- *      All segments failed  → '!'   (red)    — persists until user stops or navigates
- *   3. User stops translate → badge cleared
- *   4. Tab navigates away   → badge cleared
+ * Badge is driven from pageTranslatorStatsUpdated (segment counters) rather than
+ * pageTranslatorStateUpdated (on/off) to avoid a race where stats messages arrive
+ * before the state message at the service worker.
  *
- * Design notes:
- * - Badge state is driven primarily from pageTranslatorStatsUpdated (segment counters)
- *   rather than pageTranslatorStateUpdated (on/off). This avoids a race condition where
- *   stats messages arrive at the service worker before the state message, because
- *   PageTranslatorController fires the effector store update (which synchronously starts
- *   translation and emits the first stats) before calling notifyState().
- * - enable() must be called synchronously during service worker startup, before any
- *   awaited operations, so that the runtime.onMessage listener is registered before
- *   the first message arrives on wake-up.
+ * enable() must be called synchronously during service worker startup so the
+ * runtime.onMessage listener is registered before the first message arrives.
  */
 export class ActionBadgeController {
-	// Tracks any pending timers per tab. Currently unused for auto-clear (all badges
-	// persist until explicitly cleared), but kept for safety so cancelClearTimer()
-	// can always be called unconditionally before any badge update.
 	private readonly clearTimers = new Map<number, ReturnType<typeof setTimeout>>();
-
 	private isEnabled = false;
 	private cleanupCallback: null | (() => void) = null;
 
@@ -49,59 +31,39 @@ export class ActionBadgeController {
 		if (this.isEnabled) return;
 		this.isEnabled = true;
 
-		// Listen for translation on/off events from the content script.
-		// Used to clear the badge when the user manually stops translation.
-		// The '...' badge is NOT set here — see stats handler below.
 		const unwatchState = pageTranslatorStateUpdatedHandler((state, tabId) => {
 			if (tabId === undefined) return;
-
 			if (!state.isTranslated) {
-				// User stopped translation — clear badge
 				this.cancelClearTimer(tabId);
 				this.clearBadge(tabId);
 			}
 		});
 
-		// Listen for segment counter updates from the content script.
-		// This is the primary driver for all badge states, including '...'.
-		// Fired at most every 100ms (throttled in PageTranslator).
 		const unwatchStats = pageTranslatorStatsUpdatedHandler((stats, tabId) => {
 			if (tabId === undefined) return;
 
 			const { resolved, rejected, pending } = stats;
 
-			// PageTranslator.stop() resets counters to zero and flushes one last stats
-			// message before sending the state-updated message. Ignore it here — the
-			// state handler above will clear the badge when isTranslated goes false.
+			// PageTranslator.stop() emits a zero-counters flush before the state message — ignore it.
 			if (pending === 0 && resolved === 0 && rejected === 0) return;
 
 			if (pending > 0) {
-				// Segments still in flight — show progress badge.
-				// Driving '...' from stats (rather than from the state event) ensures
-				// it appears even if the state message arrives out of order.
 				this.cancelClearTimer(tabId);
 				this.setBadge(tabId, BADGE_TRANSLATING);
 				return;
 			}
 
-			// All segments have settled — show final result badge.
+			this.cancelClearTimer(tabId);
 			if (resolved > 0 && rejected === 0) {
-				// Every segment translated successfully
-				this.cancelClearTimer(tabId);
 				this.setBadge(tabId, BADGE_DONE);
 			} else if (resolved > 0 && rejected > 0) {
-				// Mixed result — page is partially translated
-				this.cancelClearTimer(tabId);
 				this.setBadge(tabId, BADGE_PARTIAL);
 			} else {
-				// resolved === 0, rejected > 0 — translation failed entirely
-				this.cancelClearTimer(tabId);
 				this.setBadge(tabId, BADGE_ERROR);
 			}
 		});
 
-		// Clear badge when the user navigates to a different URL in the tab.
-		// changeInfo.url is only present on actual navigations, not on tab focus changes.
+		// changeInfo.url is only present on actual navigations, not focus changes.
 		const onTabUpdated = (
 			tabId: number,
 			changeInfo: browser.Tabs.OnUpdatedChangeInfoType,
@@ -112,7 +74,6 @@ export class ActionBadgeController {
 			}
 		};
 
-		// Clean up timer state when a tab is closed (badge is destroyed with the tab anyway).
 		const onTabRemoved = (tabId: number) => {
 			this.cancelClearTimer(tabId);
 		};
@@ -120,7 +81,6 @@ export class ActionBadgeController {
 		browser.tabs.onUpdated.addListener(onTabUpdated);
 		browser.tabs.onRemoved.addListener(onTabRemoved);
 
-		// Store cleanup callbacks so disable() can remove all listeners cleanly.
 		this.cleanupCallback = () => {
 			unwatchState();
 			unwatchStats();

--- a/src/app/ConfigStorage/ConfigStorage.migrations.ts
+++ b/src/app/ConfigStorage/ConfigStorage.migrations.ts
@@ -186,6 +186,28 @@ const migrations: Migration[] = [
 			await browser.storage.local.set({ [storageName]: updatedConfig });
 		},
 	},
+	{
+		version: 10,
+		async migrate() {
+			const storageName = 'appConfig';
+
+			let { [storageName]: actualData } =
+				await browser.storage.local.get(storageName);
+			if (typeof actualData !== 'object') {
+				actualData = {};
+			}
+
+			const updatedConfig = {
+				...actualData,
+				pageTranslator: {
+					showTranslationBadge: false,
+					...actualData?.pageTranslator,
+				},
+			};
+
+			await browser.storage.local.set({ [storageName]: updatedConfig });
+		},
+	},
 ];
 
 export const ConfigStorageMigration = createMigrationTask(migrations, {

--- a/src/app/ConfigStorage/__test__/ConfigStorage.test.ts
+++ b/src/app/ConfigStorage/__test__/ConfigStorage.test.ts
@@ -9,7 +9,7 @@ import { ConfigStorageMigration } from '../ConfigStorage.migrations';
 import configVersion1 from './config-v1.json';
 import configVersion3 from './config-v3.json';
 
-const latestVersion = 9;
+const latestVersion = 10;
 
 describe('config migrations', () => {
 	beforeAll(clearAllMocks);

--- a/src/app/ConfigStorage/__test__/__snapshots__/ConfigStorage.test.ts.snap
+++ b/src/app/ConfigStorage/__test__/__snapshots__/ConfigStorage.test.ts.snap
@@ -13,108 +13,57 @@ exports[`config migrations > migrate config v0 to latest version 1`] = `
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags
-",
-      "meta
-",
-      "link
-",
-      "script
-",
-      "noscript
-",
-      "style
-",
-      "code
-",
-      "pre
-",
-      "textarea
-",
-      "time
-",
-      "kbd
-",
-      "svg
-",
-      "g
-",
-      "ruby
-",
-      "rt
-",
-      "rp
-",
-      "math
-",
-      "d-math
-",
-      "samp
-",
-      "
-",
-      "! Elements that request to disable translation
-",
-      ".notranslate
-",
-      "[contenteditable="true"]
-",
-      "[translate=no]
-",
-      "
-",
-      "! Social sharing buttons
-",
-      ".social-share
-",
-      ".share-nav
-",
-      "[data-toolbar=share]
-",
-      ".o-share
-",
-      "
-",
-      "! Code elements
-",
-      ".prism-code
-",
-      ".enlighter-code
-",
-      ".rc-CodeBlock
-",
-      "[role=code]
-",
-      "table.highlight
-",
-      "
-",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
-",
-      "hypothesis-highlight
-",
-      ".hypothesis-highlight
-",
-      "
-",
-      "! Icons
-",
-      ".material-icons
-",
-      "material-icon
-",
-      "span[class^=material-symbols-]
-",
-      ".google-symbols
-",
-      "i.fa
-",
-      "i[class^=fa-]
-",
-      "
-",
-      "! Other
-",
+      "! Basic tags",
+      "meta",
+      "link",
+      "script",
+      "noscript",
+      "style",
+      "code",
+      "pre",
+      "textarea",
+      "time",
+      "kbd",
+      "svg",
+      "g",
+      "ruby",
+      "rt",
+      "rp",
+      "math",
+      "d-math",
+      "samp",
+      "",
+      "! Elements that request to disable translation",
+      ".notranslate",
+      "[contenteditable="true"]",
+      "[translate=no]",
+      "",
+      "! Social sharing buttons",
+      ".social-share",
+      ".share-nav",
+      "[data-toolbar=share]",
+      ".o-share",
+      "",
+      "! Code elements",
+      ".prism-code",
+      ".enlighter-code",
+      ".rc-CodeBlock",
+      "[role=code]",
+      "table.highlight",
+      "",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
+      "hypothesis-highlight",
+      ".hypothesis-highlight",
+      "",
+      "! Icons",
+      ".material-icons",
+      "material-icon",
+      "span[class^=material-symbols-]",
+      ".google-symbols",
+      "i.fa",
+      "i[class^=fa-]",
+      "",
+      "! Other",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
@@ -185,108 +134,57 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags
-",
-      "meta
-",
-      "link
-",
-      "script
-",
-      "noscript
-",
-      "style
-",
-      "code
-",
-      "pre
-",
-      "textarea
-",
-      "time
-",
-      "kbd
-",
-      "svg
-",
-      "g
-",
-      "ruby
-",
-      "rt
-",
-      "rp
-",
-      "math
-",
-      "d-math
-",
-      "samp
-",
-      "
-",
-      "! Elements that request to disable translation
-",
-      ".notranslate
-",
-      "[contenteditable="true"]
-",
-      "[translate=no]
-",
-      "
-",
-      "! Social sharing buttons
-",
-      ".social-share
-",
-      ".share-nav
-",
-      "[data-toolbar=share]
-",
-      ".o-share
-",
-      "
-",
-      "! Code elements
-",
-      ".prism-code
-",
-      ".enlighter-code
-",
-      ".rc-CodeBlock
-",
-      "[role=code]
-",
-      "table.highlight
-",
-      "
-",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
-",
-      "hypothesis-highlight
-",
-      ".hypothesis-highlight
-",
-      "
-",
-      "! Icons
-",
-      ".material-icons
-",
-      "material-icon
-",
-      "span[class^=material-symbols-]
-",
-      ".google-symbols
-",
-      "i.fa
-",
-      "i[class^=fa-]
-",
-      "
-",
-      "! Other
-",
+      "! Basic tags",
+      "meta",
+      "link",
+      "script",
+      "noscript",
+      "style",
+      "code",
+      "pre",
+      "textarea",
+      "time",
+      "kbd",
+      "svg",
+      "g",
+      "ruby",
+      "rt",
+      "rp",
+      "math",
+      "d-math",
+      "samp",
+      "",
+      "! Elements that request to disable translation",
+      ".notranslate",
+      "[contenteditable="true"]",
+      "[translate=no]",
+      "",
+      "! Social sharing buttons",
+      ".social-share",
+      ".share-nav",
+      "[data-toolbar=share]",
+      ".o-share",
+      "",
+      "! Code elements",
+      ".prism-code",
+      ".enlighter-code",
+      ".rc-CodeBlock",
+      "[role=code]",
+      "table.highlight",
+      "",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
+      "hypothesis-highlight",
+      ".hypothesis-highlight",
+      "",
+      "! Icons",
+      ".material-icons",
+      "material-icon",
+      "span[class^=material-symbols-]",
+      ".google-symbols",
+      "i.fa",
+      "i[class^=fa-]",
+      "",
+      "! Other",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
@@ -357,108 +255,57 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags
-",
-      "meta
-",
-      "link
-",
-      "script
-",
-      "noscript
-",
-      "style
-",
-      "code
-",
-      "pre
-",
-      "textarea
-",
-      "time
-",
-      "kbd
-",
-      "svg
-",
-      "g
-",
-      "ruby
-",
-      "rt
-",
-      "rp
-",
-      "math
-",
-      "d-math
-",
-      "samp
-",
-      "
-",
-      "! Elements that request to disable translation
-",
-      ".notranslate
-",
-      "[contenteditable="true"]
-",
-      "[translate=no]
-",
-      "
-",
-      "! Social sharing buttons
-",
-      ".social-share
-",
-      ".share-nav
-",
-      "[data-toolbar=share]
-",
-      ".o-share
-",
-      "
-",
-      "! Code elements
-",
-      ".prism-code
-",
-      ".enlighter-code
-",
-      ".rc-CodeBlock
-",
-      "[role=code]
-",
-      "table.highlight
-",
-      "
-",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
-",
-      "hypothesis-highlight
-",
-      ".hypothesis-highlight
-",
-      "
-",
-      "! Icons
-",
-      ".material-icons
-",
-      "material-icon
-",
-      "span[class^=material-symbols-]
-",
-      ".google-symbols
-",
-      "i.fa
-",
-      "i[class^=fa-]
-",
-      "
-",
-      "! Other
-",
+      "! Basic tags",
+      "meta",
+      "link",
+      "script",
+      "noscript",
+      "style",
+      "code",
+      "pre",
+      "textarea",
+      "time",
+      "kbd",
+      "svg",
+      "g",
+      "ruby",
+      "rt",
+      "rp",
+      "math",
+      "d-math",
+      "samp",
+      "",
+      "! Elements that request to disable translation",
+      ".notranslate",
+      "[contenteditable="true"]",
+      "[translate=no]",
+      "",
+      "! Social sharing buttons",
+      ".social-share",
+      ".share-nav",
+      "[data-toolbar=share]",
+      ".o-share",
+      "",
+      "! Code elements",
+      ".prism-code",
+      ".enlighter-code",
+      ".rc-CodeBlock",
+      "[role=code]",
+      "table.highlight",
+      "",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
+      "hypothesis-highlight",
+      ".hypothesis-highlight",
+      "",
+      "! Icons",
+      ".material-icons",
+      "material-icon",
+      "span[class^=material-symbols-]",
+      ".google-symbols",
+      "i.fa",
+      "i[class^=fa-]",
+      "",
+      "! Other",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
@@ -529,108 +376,57 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags
-",
-      "meta
-",
-      "link
-",
-      "script
-",
-      "noscript
-",
-      "style
-",
-      "code
-",
-      "pre
-",
-      "textarea
-",
-      "time
-",
-      "kbd
-",
-      "svg
-",
-      "g
-",
-      "ruby
-",
-      "rt
-",
-      "rp
-",
-      "math
-",
-      "d-math
-",
-      "samp
-",
-      "
-",
-      "! Elements that request to disable translation
-",
-      ".notranslate
-",
-      "[contenteditable="true"]
-",
-      "[translate=no]
-",
-      "
-",
-      "! Social sharing buttons
-",
-      ".social-share
-",
-      ".share-nav
-",
-      "[data-toolbar=share]
-",
-      ".o-share
-",
-      "
-",
-      "! Code elements
-",
-      ".prism-code
-",
-      ".enlighter-code
-",
-      ".rc-CodeBlock
-",
-      "[role=code]
-",
-      "table.highlight
-",
-      "
-",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
-",
-      "hypothesis-highlight
-",
-      ".hypothesis-highlight
-",
-      "
-",
-      "! Icons
-",
-      ".material-icons
-",
-      "material-icon
-",
-      "span[class^=material-symbols-]
-",
-      ".google-symbols
-",
-      "i.fa
-",
-      "i[class^=fa-]
-",
-      "
-",
-      "! Other
-",
+      "! Basic tags",
+      "meta",
+      "link",
+      "script",
+      "noscript",
+      "style",
+      "code",
+      "pre",
+      "textarea",
+      "time",
+      "kbd",
+      "svg",
+      "g",
+      "ruby",
+      "rt",
+      "rp",
+      "math",
+      "d-math",
+      "samp",
+      "",
+      "! Elements that request to disable translation",
+      ".notranslate",
+      "[contenteditable="true"]",
+      "[translate=no]",
+      "",
+      "! Social sharing buttons",
+      ".social-share",
+      ".share-nav",
+      "[data-toolbar=share]",
+      ".o-share",
+      "",
+      "! Code elements",
+      ".prism-code",
+      ".enlighter-code",
+      ".rc-CodeBlock",
+      "[role=code]",
+      "table.highlight",
+      "",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
+      "hypothesis-highlight",
+      ".hypothesis-highlight",
+      "",
+      "! Icons",
+      ".material-icons",
+      "material-icon",
+      "span[class^=material-symbols-]",
+      ".google-symbols",
+      "i.fa",
+      "i[class^=fa-]",
+      "",
+      "! Other",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
@@ -701,108 +497,57 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags
-",
-      "meta
-",
-      "link
-",
-      "script
-",
-      "noscript
-",
-      "style
-",
-      "code
-",
-      "pre
-",
-      "textarea
-",
-      "time
-",
-      "kbd
-",
-      "svg
-",
-      "g
-",
-      "ruby
-",
-      "rt
-",
-      "rp
-",
-      "math
-",
-      "d-math
-",
-      "samp
-",
-      "
-",
-      "! Elements that request to disable translation
-",
-      ".notranslate
-",
-      "[contenteditable="true"]
-",
-      "[translate=no]
-",
-      "
-",
-      "! Social sharing buttons
-",
-      ".social-share
-",
-      ".share-nav
-",
-      "[data-toolbar=share]
-",
-      ".o-share
-",
-      "
-",
-      "! Code elements
-",
-      ".prism-code
-",
-      ".enlighter-code
-",
-      ".rc-CodeBlock
-",
-      "[role=code]
-",
-      "table.highlight
-",
-      "
-",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
-",
-      "hypothesis-highlight
-",
-      ".hypothesis-highlight
-",
-      "
-",
-      "! Icons
-",
-      ".material-icons
-",
-      "material-icon
-",
-      "span[class^=material-symbols-]
-",
-      ".google-symbols
-",
-      "i.fa
-",
-      "i[class^=fa-]
-",
-      "
-",
-      "! Other
-",
+      "! Basic tags",
+      "meta",
+      "link",
+      "script",
+      "noscript",
+      "style",
+      "code",
+      "pre",
+      "textarea",
+      "time",
+      "kbd",
+      "svg",
+      "g",
+      "ruby",
+      "rt",
+      "rp",
+      "math",
+      "d-math",
+      "samp",
+      "",
+      "! Elements that request to disable translation",
+      ".notranslate",
+      "[contenteditable="true"]",
+      "[translate=no]",
+      "",
+      "! Social sharing buttons",
+      ".social-share",
+      ".share-nav",
+      "[data-toolbar=share]",
+      ".o-share",
+      "",
+      "! Code elements",
+      ".prism-code",
+      ".enlighter-code",
+      ".rc-CodeBlock",
+      "[role=code]",
+      "table.highlight",
+      "",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
+      "hypothesis-highlight",
+      ".hypothesis-highlight",
+      "",
+      "! Icons",
+      ".material-icons",
+      "material-icon",
+      "span[class^=material-symbols-]",
+      ".google-symbols",
+      "i.fa",
+      "i[class^=fa-]",
+      "",
+      "! Other",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
@@ -873,108 +618,57 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags
-",
-      "meta
-",
-      "link
-",
-      "script
-",
-      "noscript
-",
-      "style
-",
-      "code
-",
-      "pre
-",
-      "textarea
-",
-      "time
-",
-      "kbd
-",
-      "svg
-",
-      "g
-",
-      "ruby
-",
-      "rt
-",
-      "rp
-",
-      "math
-",
-      "d-math
-",
-      "samp
-",
-      "
-",
-      "! Elements that request to disable translation
-",
-      ".notranslate
-",
-      "[contenteditable="true"]
-",
-      "[translate=no]
-",
-      "
-",
-      "! Social sharing buttons
-",
-      ".social-share
-",
-      ".share-nav
-",
-      "[data-toolbar=share]
-",
-      ".o-share
-",
-      "
-",
-      "! Code elements
-",
-      ".prism-code
-",
-      ".enlighter-code
-",
-      ".rc-CodeBlock
-",
-      "[role=code]
-",
-      "table.highlight
-",
-      "
-",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
-",
-      "hypothesis-highlight
-",
-      ".hypothesis-highlight
-",
-      "
-",
-      "! Icons
-",
-      ".material-icons
-",
-      "material-icon
-",
-      "span[class^=material-symbols-]
-",
-      ".google-symbols
-",
-      "i.fa
-",
-      "i[class^=fa-]
-",
-      "
-",
-      "! Other
-",
+      "! Basic tags",
+      "meta",
+      "link",
+      "script",
+      "noscript",
+      "style",
+      "code",
+      "pre",
+      "textarea",
+      "time",
+      "kbd",
+      "svg",
+      "g",
+      "ruby",
+      "rt",
+      "rp",
+      "math",
+      "d-math",
+      "samp",
+      "",
+      "! Elements that request to disable translation",
+      ".notranslate",
+      "[contenteditable="true"]",
+      "[translate=no]",
+      "",
+      "! Social sharing buttons",
+      ".social-share",
+      ".share-nav",
+      "[data-toolbar=share]",
+      ".o-share",
+      "",
+      "! Code elements",
+      ".prism-code",
+      ".enlighter-code",
+      ".rc-CodeBlock",
+      "[role=code]",
+      "table.highlight",
+      "",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
+      "hypothesis-highlight",
+      ".hypothesis-highlight",
+      "",
+      "! Icons",
+      ".material-icons",
+      "material-icon",
+      "span[class^=material-symbols-]",
+      ".google-symbols",
+      "i.fa",
+      "i[class^=fa-]",
+      "",
+      "! Other",
       "visuallyhidden",
     ],
     "lazyTranslate": true,

--- a/src/app/ConfigStorage/__test__/__snapshots__/ConfigStorage.test.ts.snap
+++ b/src/app/ConfigStorage/__test__/__snapshots__/ConfigStorage.test.ts.snap
@@ -13,61 +13,113 @@ exports[`config migrations > migrate config v0 to latest version 1`] = `
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags",
-      "meta",
-      "link",
-      "script",
-      "noscript",
-      "style",
-      "code",
-      "pre",
-      "textarea",
-      "time",
-      "kbd",
-      "svg",
-      "g",
-      "ruby",
-      "rt",
-      "rp",
-      "math",
-      "d-math",
-      "samp",
-      "",
-      "! Elements that request to disable translation",
-      ".notranslate",
-      "[contenteditable="true"]",
-      "[translate=no]",
-      "",
-      "! Social sharing buttons",
-      ".social-share",
-      ".share-nav",
-      "[data-toolbar=share]",
-      ".o-share",
-      "",
-      "! Code elements",
-      ".prism-code",
-      ".enlighter-code",
-      ".rc-CodeBlock",
-      "[role=code]",
-      "table.highlight",
-      "",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
-      "hypothesis-highlight",
-      ".hypothesis-highlight",
-      "",
-      "! Icons",
-      ".material-icons",
-      "material-icon",
-      "span[class^=material-symbols-]",
-      ".google-symbols",
-      "i.fa",
-      "i[class^=fa-]",
-      "",
-      "! Other",
+      "! Basic tags
+",
+      "meta
+",
+      "link
+",
+      "script
+",
+      "noscript
+",
+      "style
+",
+      "code
+",
+      "pre
+",
+      "textarea
+",
+      "time
+",
+      "kbd
+",
+      "svg
+",
+      "g
+",
+      "ruby
+",
+      "rt
+",
+      "rp
+",
+      "math
+",
+      "d-math
+",
+      "samp
+",
+      "
+",
+      "! Elements that request to disable translation
+",
+      ".notranslate
+",
+      "[contenteditable="true"]
+",
+      "[translate=no]
+",
+      "
+",
+      "! Social sharing buttons
+",
+      ".social-share
+",
+      ".share-nav
+",
+      "[data-toolbar=share]
+",
+      ".o-share
+",
+      "
+",
+      "! Code elements
+",
+      ".prism-code
+",
+      ".enlighter-code
+",
+      ".rc-CodeBlock
+",
+      "[role=code]
+",
+      "table.highlight
+",
+      "
+",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
+",
+      "hypothesis-highlight
+",
+      ".hypothesis-highlight
+",
+      "
+",
+      "! Icons
+",
+      ".material-icons
+",
+      "material-icon
+",
+      "span[class^=material-symbols-]
+",
+      ".google-symbols
+",
+      "i.fa
+",
+      "i[class^=fa-]
+",
+      "
+",
+      "! Other
+",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
     "originalTextPopup": false,
+    "showTranslationBadge": false,
     "toggleTranslationHotkey": null,
     "translatableAttributes": [
       "title",
@@ -133,61 +185,113 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags",
-      "meta",
-      "link",
-      "script",
-      "noscript",
-      "style",
-      "code",
-      "pre",
-      "textarea",
-      "time",
-      "kbd",
-      "svg",
-      "g",
-      "ruby",
-      "rt",
-      "rp",
-      "math",
-      "d-math",
-      "samp",
-      "",
-      "! Elements that request to disable translation",
-      ".notranslate",
-      "[contenteditable="true"]",
-      "[translate=no]",
-      "",
-      "! Social sharing buttons",
-      ".social-share",
-      ".share-nav",
-      "[data-toolbar=share]",
-      ".o-share",
-      "",
-      "! Code elements",
-      ".prism-code",
-      ".enlighter-code",
-      ".rc-CodeBlock",
-      "[role=code]",
-      "table.highlight",
-      "",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
-      "hypothesis-highlight",
-      ".hypothesis-highlight",
-      "",
-      "! Icons",
-      ".material-icons",
-      "material-icon",
-      "span[class^=material-symbols-]",
-      ".google-symbols",
-      "i.fa",
-      "i[class^=fa-]",
-      "",
-      "! Other",
+      "! Basic tags
+",
+      "meta
+",
+      "link
+",
+      "script
+",
+      "noscript
+",
+      "style
+",
+      "code
+",
+      "pre
+",
+      "textarea
+",
+      "time
+",
+      "kbd
+",
+      "svg
+",
+      "g
+",
+      "ruby
+",
+      "rt
+",
+      "rp
+",
+      "math
+",
+      "d-math
+",
+      "samp
+",
+      "
+",
+      "! Elements that request to disable translation
+",
+      ".notranslate
+",
+      "[contenteditable="true"]
+",
+      "[translate=no]
+",
+      "
+",
+      "! Social sharing buttons
+",
+      ".social-share
+",
+      ".share-nav
+",
+      "[data-toolbar=share]
+",
+      ".o-share
+",
+      "
+",
+      "! Code elements
+",
+      ".prism-code
+",
+      ".enlighter-code
+",
+      ".rc-CodeBlock
+",
+      "[role=code]
+",
+      "table.highlight
+",
+      "
+",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
+",
+      "hypothesis-highlight
+",
+      ".hypothesis-highlight
+",
+      "
+",
+      "! Icons
+",
+      ".material-icons
+",
+      "material-icon
+",
+      "span[class^=material-symbols-]
+",
+      ".google-symbols
+",
+      "i.fa
+",
+      "i[class^=fa-]
+",
+      "
+",
+      "! Other
+",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
     "originalTextPopup": false,
+    "showTranslationBadge": false,
     "toggleTranslationHotkey": null,
     "translatableAttributes": [
       "title",
@@ -253,61 +357,113 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags",
-      "meta",
-      "link",
-      "script",
-      "noscript",
-      "style",
-      "code",
-      "pre",
-      "textarea",
-      "time",
-      "kbd",
-      "svg",
-      "g",
-      "ruby",
-      "rt",
-      "rp",
-      "math",
-      "d-math",
-      "samp",
-      "",
-      "! Elements that request to disable translation",
-      ".notranslate",
-      "[contenteditable="true"]",
-      "[translate=no]",
-      "",
-      "! Social sharing buttons",
-      ".social-share",
-      ".share-nav",
-      "[data-toolbar=share]",
-      ".o-share",
-      "",
-      "! Code elements",
-      ".prism-code",
-      ".enlighter-code",
-      ".rc-CodeBlock",
-      "[role=code]",
-      "table.highlight",
-      "",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
-      "hypothesis-highlight",
-      ".hypothesis-highlight",
-      "",
-      "! Icons",
-      ".material-icons",
-      "material-icon",
-      "span[class^=material-symbols-]",
-      ".google-symbols",
-      "i.fa",
-      "i[class^=fa-]",
-      "",
-      "! Other",
+      "! Basic tags
+",
+      "meta
+",
+      "link
+",
+      "script
+",
+      "noscript
+",
+      "style
+",
+      "code
+",
+      "pre
+",
+      "textarea
+",
+      "time
+",
+      "kbd
+",
+      "svg
+",
+      "g
+",
+      "ruby
+",
+      "rt
+",
+      "rp
+",
+      "math
+",
+      "d-math
+",
+      "samp
+",
+      "
+",
+      "! Elements that request to disable translation
+",
+      ".notranslate
+",
+      "[contenteditable="true"]
+",
+      "[translate=no]
+",
+      "
+",
+      "! Social sharing buttons
+",
+      ".social-share
+",
+      ".share-nav
+",
+      "[data-toolbar=share]
+",
+      ".o-share
+",
+      "
+",
+      "! Code elements
+",
+      ".prism-code
+",
+      ".enlighter-code
+",
+      ".rc-CodeBlock
+",
+      "[role=code]
+",
+      "table.highlight
+",
+      "
+",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
+",
+      "hypothesis-highlight
+",
+      ".hypothesis-highlight
+",
+      "
+",
+      "! Icons
+",
+      ".material-icons
+",
+      "material-icon
+",
+      "span[class^=material-symbols-]
+",
+      ".google-symbols
+",
+      "i.fa
+",
+      "i[class^=fa-]
+",
+      "
+",
+      "! Other
+",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
     "originalTextPopup": false,
+    "showTranslationBadge": false,
     "toggleTranslationHotkey": null,
     "translatableAttributes": [
       "title",
@@ -373,61 +529,113 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags",
-      "meta",
-      "link",
-      "script",
-      "noscript",
-      "style",
-      "code",
-      "pre",
-      "textarea",
-      "time",
-      "kbd",
-      "svg",
-      "g",
-      "ruby",
-      "rt",
-      "rp",
-      "math",
-      "d-math",
-      "samp",
-      "",
-      "! Elements that request to disable translation",
-      ".notranslate",
-      "[contenteditable="true"]",
-      "[translate=no]",
-      "",
-      "! Social sharing buttons",
-      ".social-share",
-      ".share-nav",
-      "[data-toolbar=share]",
-      ".o-share",
-      "",
-      "! Code elements",
-      ".prism-code",
-      ".enlighter-code",
-      ".rc-CodeBlock",
-      "[role=code]",
-      "table.highlight",
-      "",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
-      "hypothesis-highlight",
-      ".hypothesis-highlight",
-      "",
-      "! Icons",
-      ".material-icons",
-      "material-icon",
-      "span[class^=material-symbols-]",
-      ".google-symbols",
-      "i.fa",
-      "i[class^=fa-]",
-      "",
-      "! Other",
+      "! Basic tags
+",
+      "meta
+",
+      "link
+",
+      "script
+",
+      "noscript
+",
+      "style
+",
+      "code
+",
+      "pre
+",
+      "textarea
+",
+      "time
+",
+      "kbd
+",
+      "svg
+",
+      "g
+",
+      "ruby
+",
+      "rt
+",
+      "rp
+",
+      "math
+",
+      "d-math
+",
+      "samp
+",
+      "
+",
+      "! Elements that request to disable translation
+",
+      ".notranslate
+",
+      "[contenteditable="true"]
+",
+      "[translate=no]
+",
+      "
+",
+      "! Social sharing buttons
+",
+      ".social-share
+",
+      ".share-nav
+",
+      "[data-toolbar=share]
+",
+      ".o-share
+",
+      "
+",
+      "! Code elements
+",
+      ".prism-code
+",
+      ".enlighter-code
+",
+      ".rc-CodeBlock
+",
+      "[role=code]
+",
+      "table.highlight
+",
+      "
+",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
+",
+      "hypothesis-highlight
+",
+      ".hypothesis-highlight
+",
+      "
+",
+      "! Icons
+",
+      ".material-icons
+",
+      "material-icon
+",
+      "span[class^=material-symbols-]
+",
+      ".google-symbols
+",
+      "i.fa
+",
+      "i[class^=fa-]
+",
+      "
+",
+      "! Other
+",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
     "originalTextPopup": false,
+    "showTranslationBadge": false,
     "toggleTranslationHotkey": null,
     "translatableAttributes": [
       "title",
@@ -493,61 +701,113 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags",
-      "meta",
-      "link",
-      "script",
-      "noscript",
-      "style",
-      "code",
-      "pre",
-      "textarea",
-      "time",
-      "kbd",
-      "svg",
-      "g",
-      "ruby",
-      "rt",
-      "rp",
-      "math",
-      "d-math",
-      "samp",
-      "",
-      "! Elements that request to disable translation",
-      ".notranslate",
-      "[contenteditable="true"]",
-      "[translate=no]",
-      "",
-      "! Social sharing buttons",
-      ".social-share",
-      ".share-nav",
-      "[data-toolbar=share]",
-      ".o-share",
-      "",
-      "! Code elements",
-      ".prism-code",
-      ".enlighter-code",
-      ".rc-CodeBlock",
-      "[role=code]",
-      "table.highlight",
-      "",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
-      "hypothesis-highlight",
-      ".hypothesis-highlight",
-      "",
-      "! Icons",
-      ".material-icons",
-      "material-icon",
-      "span[class^=material-symbols-]",
-      ".google-symbols",
-      "i.fa",
-      "i[class^=fa-]",
-      "",
-      "! Other",
+      "! Basic tags
+",
+      "meta
+",
+      "link
+",
+      "script
+",
+      "noscript
+",
+      "style
+",
+      "code
+",
+      "pre
+",
+      "textarea
+",
+      "time
+",
+      "kbd
+",
+      "svg
+",
+      "g
+",
+      "ruby
+",
+      "rt
+",
+      "rp
+",
+      "math
+",
+      "d-math
+",
+      "samp
+",
+      "
+",
+      "! Elements that request to disable translation
+",
+      ".notranslate
+",
+      "[contenteditable="true"]
+",
+      "[translate=no]
+",
+      "
+",
+      "! Social sharing buttons
+",
+      ".social-share
+",
+      ".share-nav
+",
+      "[data-toolbar=share]
+",
+      ".o-share
+",
+      "
+",
+      "! Code elements
+",
+      ".prism-code
+",
+      ".enlighter-code
+",
+      ".rc-CodeBlock
+",
+      "[role=code]
+",
+      "table.highlight
+",
+      "
+",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
+",
+      "hypothesis-highlight
+",
+      ".hypothesis-highlight
+",
+      "
+",
+      "! Icons
+",
+      ".material-icons
+",
+      "material-icon
+",
+      "span[class^=material-symbols-]
+",
+      ".google-symbols
+",
+      "i.fa
+",
+      "i[class^=fa-]
+",
+      "
+",
+      "! Other
+",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
     "originalTextPopup": false,
+    "showTranslationBadge": false,
     "toggleTranslationHotkey": null,
     "translatableAttributes": [
       "title",
@@ -613,61 +873,113 @@ exports[`config migrations > race condition detection > Detection race condition
     "detectLanguageByContent": true,
     "enableContextMenu": false,
     "excludeSelectors": [
-      "! Basic tags",
-      "meta",
-      "link",
-      "script",
-      "noscript",
-      "style",
-      "code",
-      "pre",
-      "textarea",
-      "time",
-      "kbd",
-      "svg",
-      "g",
-      "ruby",
-      "rt",
-      "rp",
-      "math",
-      "d-math",
-      "samp",
-      "",
-      "! Elements that request to disable translation",
-      ".notranslate",
-      "[contenteditable="true"]",
-      "[translate=no]",
-      "",
-      "! Social sharing buttons",
-      ".social-share",
-      ".share-nav",
-      "[data-toolbar=share]",
-      ".o-share",
-      "",
-      "! Code elements",
-      ".prism-code",
-      ".enlighter-code",
-      ".rc-CodeBlock",
-      "[role=code]",
-      "table.highlight",
-      "",
-      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/",
-      "hypothesis-highlight",
-      ".hypothesis-highlight",
-      "",
-      "! Icons",
-      ".material-icons",
-      "material-icon",
-      "span[class^=material-symbols-]",
-      ".google-symbols",
-      "i.fa",
-      "i[class^=fa-]",
-      "",
-      "! Other",
+      "! Basic tags
+",
+      "meta
+",
+      "link
+",
+      "script
+",
+      "noscript
+",
+      "style
+",
+      "code
+",
+      "pre
+",
+      "textarea
+",
+      "time
+",
+      "kbd
+",
+      "svg
+",
+      "g
+",
+      "ruby
+",
+      "rt
+",
+      "rp
+",
+      "math
+",
+      "d-math
+",
+      "samp
+",
+      "
+",
+      "! Elements that request to disable translation
+",
+      ".notranslate
+",
+      "[contenteditable="true"]
+",
+      "[translate=no]
+",
+      "
+",
+      "! Social sharing buttons
+",
+      ".social-share
+",
+      ".share-nav
+",
+      "[data-toolbar=share]
+",
+      ".o-share
+",
+      "
+",
+      "! Code elements
+",
+      ".prism-code
+",
+      ".enlighter-code
+",
+      ".rc-CodeBlock
+",
+      "[role=code]
+",
+      "table.highlight
+",
+      "
+",
+      "! example: https://web.hypothes.is/blog/do-it-yourself-anchoring-and-the-evolution-of-the-hypothesis-toolkit/
+",
+      "hypothesis-highlight
+",
+      ".hypothesis-highlight
+",
+      "
+",
+      "! Icons
+",
+      ".material-icons
+",
+      "material-icon
+",
+      "span[class^=material-symbols-]
+",
+      ".google-symbols
+",
+      "i.fa
+",
+      "i[class^=fa-]
+",
+      "
+",
+      "! Other
+",
       "visuallyhidden",
     ],
     "lazyTranslate": true,
     "originalTextPopup": false,
+    "showTranslationBadge": false,
     "toggleTranslationHotkey": null,
     "translatableAttributes": [
       "title",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -9,6 +9,7 @@ import { clearCache } from '../requests/backend/clearCache';
 import { sendAppConfigUpdateEvent } from '../requests/global/appConfigUpdate';
 import { customTranslatorsFactory } from '../requests/offscreen/customTranslators';
 import { AppConfigType } from '../types/runtime';
+import { ActionBadgeController } from './ActionBadge/ActionBadgeController';
 import { Background } from './Background';
 import { requestHandlers } from './Background/requestHandlers';
 import { ConfigStorage, ObservableAsyncStorage } from './ConfigStorage/ConfigStorage';
@@ -71,6 +72,12 @@ export class App {
 		}
 
 		this.isStarted = true;
+
+		// Register badge listeners synchronously before any awaits — the first
+		// pageTranslatorStateUpdated message arrives as the service worker wakes up,
+		// before async setup completes. Registering here ensures it isn't missed.
+		const actionBadgeController = new ActionBadgeController();
+		actionBadgeController.enable();
 
 		await this.setupOffscreenDocuments();
 		await this.background.start();
@@ -174,6 +181,7 @@ export class App {
 					translatePageContextMenu.disable();
 				}
 			});
+
 	}
 
 	private readonly onInstalled = async (details: OnInstalledData) => {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -73,12 +73,6 @@ export class App {
 
 		this.isStarted = true;
 
-		// Register badge listeners synchronously before any awaits — the first
-		// pageTranslatorStateUpdated message arrives as the service worker wakes up,
-		// before async setup completes. Registering here ensures it isn't missed.
-		const actionBadgeController = new ActionBadgeController();
-		actionBadgeController.enable();
-
 		await this.setupOffscreenDocuments();
 		await this.background.start();
 
@@ -182,6 +176,16 @@ export class App {
 				}
 			});
 
+		const actionBadgeController = new ActionBadgeController();
+		$appConfig
+			.map((config) => config.pageTranslator.showTranslationBadge)
+			.watch((isEnabled) => {
+				if (isEnabled) {
+					actionBadgeController.enable();
+				} else {
+					actionBadgeController.disable();
+				}
+			});
 	}
 
 	private readonly onInstalled = async (details: OnInstalledData) => {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,6 +30,7 @@ export const defaultConfig: AppConfigType = {
 		detectLanguageByContent: true,
 		originalTextPopup: false,
 		enableContextMenu: true,
+		showTranslationBadge: false,
 		toggleTranslationHotkey: null,
 	},
 	textTranslator: {

--- a/src/pages/options/layout/OptionsPage.utils/generateTree.tsx
+++ b/src/pages/options/layout/OptionsPage.utils/generateTree.tsx
@@ -224,6 +224,18 @@ export const generateTree = ({
 					},
 				},
 				{
+					path: 'pageTranslator.showTranslationBadge',
+					description: getMessage(
+						'settings_option_pageTranslation_showTranslationBadge_desc',
+					),
+					optionContent: {
+						type: 'Checkbox',
+						text: getMessage(
+							'settings_option_pageTranslation_showTranslationBadge',
+						),
+					},
+				},
+				{
 					path: 'pageTranslator.enableContextMenu',
 					description: getMessage(
 						'settings_option_pageTranslation_enableContextMenu_desc',

--- a/src/types/runtime.ts
+++ b/src/types/runtime.ts
@@ -84,6 +84,7 @@ export const AppConfig = type.type({
 		detectLanguageByContent: type.boolean,
 		originalTextPopup: type.boolean,
 		enableContextMenu: type.boolean,
+		showTranslationBadge: type.boolean,
 		toggleTranslationHotkey: type.union([type.null, type.string]),
 	}),
 	textTranslator: type.type({

--- a/test/setupFiles/webextension.js
+++ b/test/setupFiles/webextension.js
@@ -6,6 +6,16 @@ require('jest-webextension-mock');
 
 const extBasePath = 'moz-extension://8b413e68-1e0d-4cad-b98e-1eb000799783/';
 
+// Expose MV3 chrome.action as an alias for browserAction so tests can spy on it
+// without mocking the webextension-polyfill module directly.
+// webextension-polyfill passes chrome.action.* through without Promise-wrapping when
+// it lacks metadata for the action namespace — so set mockResolvedValue here so .catch()
+// works in the controller. vi.clearAllMocks() clears call history but not implementations,
+// so this persists across tests within a file.
+globalThis.chrome.action = globalThis.chrome.browserAction;
+globalThis.chrome.browserAction.setBadgeText.mockResolvedValue(undefined);
+globalThis.chrome.browserAction.setBadgeBackgroundColor.mockResolvedValue(undefined);
+
 // Add id to run `webextension-polyfill` not in browser
 globalThis.chrome.runtime.id = 'test-extension-id';
 globalThis.chrome.runtime.getURL = (path) => String(new URL(path, extBasePath));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,10 @@ export default defineConfig({
 			load(id) {
 				const extensions = ['.txt'];
 				if (extensions.some((ext) => id.endsWith(ext))) {
-					const sqlContent = readFileSync(path.resolve(id), 'utf-8');
+					const sqlContent = readFileSync(path.resolve(id), 'utf-8').replace(
+						/\r\n/g,
+						'\n',
+					);
 					return `export default ${JSON.stringify(sqlContent)};`;
 				}
 


### PR DESCRIPTION
## Background

This badge was built while working on a companion PR adding an Ollama custom translator to [linguist-translators#10](https://github.com/translate-tools/linguist-translators/pull/10). During testing, translation failures were invisible — there was no feedback that anything had gone wrong. The badge makes translation state observable without opening the popup, which is useful for any slow or remote translator, not just Ollama.

## Summary

Adds a toolbar icon badge that reflects page translation state per tab, giving users immediate feedback without opening the popup.

## Badge states

| Badge | Colour | Meaning |
|---|---|---|
| `...` | Yellow `#f0a500` | Translation in progress |
| `✓` | Green `#3a8f3a` | All segments translated successfully |
| `~` | Orange `#e06000` | Partial success — some segments failed |
| `!` | Red `#cc0000` | All segments failed |

Badge persists until the user stops translation or navigates away.

## Implementation notes

**`src/app/ActionBadge/ActionBadgeController.ts`** — new class, follows the same pattern as `TranslatePageContextMenu`. Subscribes to `pageTranslatorStatsUpdated` (segment counters) as the primary signal for all badge states, including `...`. The `pageTranslatorStateUpdated` event is used only to clear the badge on stop.

**`src/app/index.ts`** — `ActionBadgeController.enable()` is called synchronously at the top of `App.start()`, before any `await`. This is required in MV3: the first translation message can arrive while the service worker is still completing async startup, so listeners must be registered before the first `await`.

**MV3 compatibility:** Uses `browser.action` via the webextension-polyfill (normalised for both MV2 and MV3). The `action` namespace is not yet typed in `@types/webextension-polyfill@0.9.x`; cast through `browserAction` with a comment explaining why.

## Testing

Tested on Chromium (Microsoft Edge, MV3). Not yet tested on Firefox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toolbar badge showing per-tab translation status with visual states: translating (...), complete (✓), partial (~), and error (!). Updates in real time, ignores all-zero flushes, and clears only on real navigations.
* **Settings**
  * New preference to enable/disable the translation badge (default: off).
* **Localization**
  * Added English label and description for the new badge setting.
* **Tests**
  * Added tests validating badge states, update/clear behavior, and enable/disable handling.
* **Chores**
  * Migration, config and runtime schema updated to include the new setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/translate-tools/linguist/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->