### PR TITLE
docs: update docs how to build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,3 +13,8 @@ debug.log
 # Local files
 .ADB_DEVICE
 .local
+
+# Out of scope
+.vscode
+/packages
+/thirdparty

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -11,8 +11,6 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
     types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted]
 
 # TODO: run only for changes in `site` directory
 jobs:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,7 @@ jobs:
           key: ${{ steps.cache-thirdparty-restore.outputs.cache-primary-key }}
 
       - name: Build some targets for test
-        run: make prepare buildFirefox buildFirefoxStandalone packAll lintBuilds
+        run: make prepare firefox firefox-standalone packAll lintBuilds
 
       - name: Archive build files
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,6 @@ on:
     # The branches below must be a subset of the branches above
     branches: [master]
     types: [opened, synchronize, reopened]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
           key: ${{ steps.cache-thirdparty-restore.outputs.cache-primary-key }}
 
       - name: Build some targets for test
-        run: make prepare firefox firefox-standalone packAll lintBuilds
+        run: make prepare buildAll packAll lintBuilds PLATFORMS="firefox firefox-standalone"
 
       - name: Archive build files
         uses: actions/upload-artifact@v4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     volumes:
       - ./build:/mnt/builder/build
       - ./thirdparty/bergamot/build:/mnt/builder/thirdparty/bergamot/build
+      - ./thirdparty/bergamot/src:/mnt/builder/thirdparty/bergamot/src
 
   bergamot:
     user: node

--- a/docs/dev/Development.md
+++ b/docs/dev/Development.md
@@ -13,19 +13,22 @@ If you have an ARM CPU and want to build the code, you can emulate AMD64 and run
 
 ## Build
 
-- Create a `.env` file. You may copy the `.env.example` file and configure it with your options
+- Create `.env` file. You may copy the `.env.example` file and configure it with your options
 - Run `make build` to build the whole project, package it, and check it with a linter
 - Artifacts will be placed in the `build` directory
 
 
 ## Partial build
 
-To build the extension for specific browsers only, you may run `make` with a specific target such as `buildFirefox`, `buildChromium`, etc. (see `makefile` for details). Some targets:
+To build the extension for specific browsers only, you can run `make build` and set space separated targets in parameter `PLATFORMS`.
+
+Example: `make build PLATFORMS=firefox` or `make build PLATFORMS="chrome chromium"`.
+
+Supported platforms:
 - firefox
 - chrome
-- chromium: special build with auto updates not from the Google Store
+- chromium: special build with auto updates out of the Google Store
 
-You must install dependencies and build third party code with `make prepare buildThirdparty` before running a specific target.
 
 Example command to build only the Firefox version: `make prepare buildThirdparty buildFirefox`.
 
@@ -39,6 +42,8 @@ If you change theme tokens, you also have to compile the theme files: `npm run b
 To debug on Android, [see instructions](./AndroidDebug.md).
 
 To make a custom translator, see the [translator API](../CustomTranslator.md).
+
+If you need an offline translation features, build third party code with `make prepare buildThirdparty` before run dev mode.
 
 # Tests
 

--- a/docs/dev/Development.md
+++ b/docs/dev/Development.md
@@ -20,17 +20,18 @@ If you have an ARM CPU and want to build the code, you can emulate AMD64 and run
 
 ## Partial build
 
-To build the extension for specific browsers only, you can run `make build` and set space separated targets in parameter `PLATFORMS`.
+To build the extension for specific browsers only, you can run `make build` and set space-separated targets in the `PLATFORMS` parameter.
 
 Example: `make build PLATFORMS=firefox` or `make build PLATFORMS="chrome chromium"`.
 
 Supported platforms:
 - firefox
+- firefox-standalone
 - chrome
 - chromium: special build with auto updates out of the Google Store
 
 
-Example command to build only the Firefox version: `make prepare buildThirdparty buildFirefox`.
+Example command to build only the Firefox version is `make build PLATFORMS=firefox`.
 
 
 # Development
@@ -43,7 +44,7 @@ To debug on Android, [see instructions](./AndroidDebug.md).
 
 To make a custom translator, see the [translator API](../CustomTranslator.md).
 
-If you need an offline translation features, build third party code with `make prepare buildThirdparty` before run dev mode.
+If you need offline translation features, build third-party code with `make prepare buildThirdparty` before running development mode
 
 # Tests
 

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ buildThirdparty:
 buildAll:
 	mkdir -p ./build
 	chmod 777 ./build
-	${DOCKER_COMPOSE} run --rm linguist make $(addprefix build-,$(PLATFORMS))
+	${DOCKER_COMPOSE} run --rm --build linguist make $(addprefix build-,$(PLATFORMS))
 
 # Targets below requires deps and not intended to run manually
 build-firefox:

--- a/makefile
+++ b/makefile
@@ -1,4 +1,12 @@
-include .env
+-include .env
+
+SHELL := /bin/bash
+
+DOCKER_COMPOSE ?= docker compose
+ADB_DEVICE_TO_DEBUG ?=
+FAST_BUILD ?= off
+PLATFORMS ?= firefox firefox-standalone chromium chrome 
+
 export
 
 prepare:
@@ -29,15 +37,16 @@ buildThirdparty:
 buildAll:
 	mkdir -p ./build
 	chmod 777 ./build
-	${DOCKER_COMPOSE} run --rm linguist make buildFirefox buildFirefoxStandalone buildChromium buildChrome
+	${DOCKER_COMPOSE} run --rm linguist make $(addprefix build-,$(PLATFORMS))
 
-buildFirefox:
+# Targets below requires deps and not intended to run manually
+build-firefox:
 	NODE_ENV=production EXT_TARGET=firefox npx webpack-cli -c ./webpack.config.js
-buildFirefoxStandalone:
+build-firefox-standalone:
 	NODE_ENV=production EXT_TARGET=firefox-standalone npx webpack-cli -c ./webpack.config.js
-buildChromium:
+build-chromium:
 	NODE_ENV=production EXT_TARGET=chromium npx webpack-cli -c ./webpack.config.js
-buildChrome:
+build-chrome:
 	NODE_ENV=production EXT_TARGET=chrome npx webpack-cli -c ./webpack.config.js
 
 packAll:


### PR DESCRIPTION
Closes #616

TODO:
- [x] prevent copy whole project in docker build context
- [x] prevent pull to ensure local build
- [x] ensure rebuild docker image for each run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated build instructions with unified commands and configurable platform selection.
  * Added guidance for standalone Firefox builds and clarified offline-translation development requirements.
  * Documented Chromium’s automatic updates through the Google Store.

* **Chores**
  * Added configurable container, debugging-device, fast-build, and platform settings.
  * Standardized production build command naming.
  * Streamlined automated checks by removing unnecessary review-triggered runs.
  * Improved build environment handling for third-party translation components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->