### PR TITLE
build: node version is deprecated in bergamot docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM node:20
+FROM node:26
 WORKDIR /mnt/builder
 
 RUN apt-get update
-
-# Puppeteer deps
-RUN apt-get install -y gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libnss3 lsb-release xdg-utils wget
 
 # Sys utils
 RUN apt-get install -y zip gzip tar cmake

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ build: clean prepare buildThirdparty buildAll packAll lintBuilds
 
 buildThirdparty:
 	mkdir -p ./thirdparty/bergamot/build && chmod 777 ./thirdparty/bergamot/build
-	${DOCKER_COMPOSE} run --rm bergamot make build
+	${DOCKER_COMPOSE} run --rm --build bergamot make build
 
 buildAll:
 	mkdir -p ./build

--- a/thirdparty/bergamot/Dockerfile
+++ b/thirdparty/bergamot/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:26
 WORKDIR /mnt/bergamot
 
 # Install system deps


### PR DESCRIPTION
Closes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application and Bergamot build environments to Node.js 26.
  * Third-party builds now rebuild the relevant container image before running.
  * Removed installation of previously bundled browser runtime packages from the container setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->